### PR TITLE
windows: Pass empty string to FlutterEngine::Run to workaround crash

### DIFF
--- a/platform/windows/CHANGELOG.md
+++ b/platform/windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.2 - 2022-12-13
+- Pass empty string to `FlutterEngine::Run` to workaround crash
+  (https://github.com/flutter/flutter/issues/116753)
+
 ## 2.1.1 - 2022-09-21
 - Minimum size of controller window
 

--- a/platform/windows/build_settings.yaml
+++ b/platform/windows/build_settings.yaml
@@ -2,7 +2,7 @@
 
 # Version of the Monarch Windows app. Avoid pre-releases until
 # we have tested that the Windows build works with pre-releases.
-version: 2.2.1
+version: 2.2.2
 
 # Relative path from gen\runner directory. Use double back-slashes.
 app_icon_path: ..\\..\\src\\resources\\monarch_app_icon.ico

--- a/platform/windows/src/main.cpp
+++ b/platform/windows/src/main.cpp
@@ -74,13 +74,11 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   // plugins.
   ::CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
 
-
-  //_logger.shout("start sleep");
-  //Sleep(10000);
-  //_logger.shout("end sleep");
-
-
   Logger _logger{ L"Main" };
+
+  // _logger.shout("start sleep");
+  // Sleep(20000);
+  // _logger.shout("end sleep");
 
   std::vector<std::string> arguments = GetCommandLineArguments();
 

--- a/platform/windows/src/monarch_window.cpp
+++ b/platform/windows/src/monarch_window.cpp
@@ -430,7 +430,7 @@ PreviewApiRunner::~PreviewApiRunner()
 void PreviewApiRunner::run()
 {
 	engine_ = std::make_unique<flutter::FlutterEngine>(project_);
-	engine_->Run();
+	engine_->Run("");
 }
 
 flutter::BinaryMessenger* PreviewApiRunner::messenger()


### PR DESCRIPTION
Pass empty string to `FlutterEngine::Run` to workaround crash in flutter beta version `3.7.0-1.1.pre`: https://github.com/flutter/flutter/issues/116753