### PR TITLE
Detect reload crash, notify user of workaround, fix hot restart

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.1 - 2023-02-17
+- Detect hot reload crash and notify user of workaround
+
 ## 3.0.0 - 2023-01-27
 - Linux support
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 3.0.1 - 2023-02-17
+## 3.0.1 - 2023-02-20
 - Detect hot reload crash and notify user of workaround
+- Use monarch_grpc 2.2.0
 
 ## 3.0.0 - 2023-01-27
 - Linux support

--- a/cli/lib/execute_task_runner.dart
+++ b/cli/lib/execute_task_runner.dart
@@ -17,6 +17,7 @@ import 'src/config/validator.dart';
 import 'src/config/notifications_reader.dart';
 import 'src/crash_reports/crash_reports.dart';
 import 'src/monarch_ui/monarch_ui_fetcher.dart';
+import 'src/task_runner/notifications.dart';
 import 'src/utils/cli_exit_code.dart';
 import 'src/task_runner/log_stream_stdout_writer.dart';
 import 'src/utils/log_stream_file_writer.dart';
@@ -131,7 +132,7 @@ The monarch_ui directory below is missing. Make sure to add your Flutter SDK pat
   }
 
   final notifications = await notificationsReader.notifications;
-  _showNotifications(notifications);
+  showNotifications(notifications, stdout_default, _analytics);
 
   _grpc = Grpc();
   try {
@@ -288,12 +289,3 @@ Future<CliExitCode> _fetchMonarchUi(ProjectConfig projectConfig,
   return uiFetchExitCode;
 }
 
-void _showNotifications(List<Notification> notifications) {
-  for (var notification in notifications) {
-    stdout_default.writeln();
-    stdout_default.writeln('*' * 80);
-    stdout_default.writeln(notification.message.trim());
-    stdout_default.writeln('*' * 80);
-    _analytics.notification_displayed(notification.id);
-  }
-}

--- a/cli/lib/src/task_runner/key_commands.dart
+++ b/cli/lib/src/task_runner/key_commands.dart
@@ -69,7 +69,7 @@ class HotRestartKeyCommand extends KeyCommand {
     running(() async {
       var heartbeat = Heartbeat(kReloadingStoriesHotRestart, stdout_.writeln);
       heartbeat.start();
-      var reloader = HotRestarter(bundleTask, previewApi);
+      var reloader = HotRestarter(bundleTask, previewApi, stdout_);
       await reloader.reload(heartbeat);
     });
   }
@@ -166,11 +166,13 @@ class GenerateAndHotRestartKeyCommand extends KeyCommand {
   final ProcessTask generateTask;
   final ProcessTask bundleTask;
   final PreviewApi previewApi;
+  final StandardOutput stdout_;
 
   GenerateAndHotRestartKeyCommand({
     required this.generateTask,
     required this.bundleTask,
     required this.previewApi,
+    required this.stdout_,
   });
 
   @override
@@ -182,7 +184,7 @@ class GenerateAndHotRestartKeyCommand extends KeyCommand {
       await generateTask.run();
       await generateTask.done();
 
-      var reloader = HotRestarter(bundleTask, previewApi);
+      var reloader = HotRestarter(bundleTask, previewApi, stdout_);
       await reloader.reload(heartbeat);
     });
   }

--- a/cli/lib/src/task_runner/monarch_app_stderr.dart
+++ b/cli/lib/src/task_runner/monarch_app_stderr.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:monarch_utils/log.dart';
 
 import 'task_names.dart';
+import 'reload_crash.dart' as reload_crash;
 
 /// This funcion handles scenarios where the platform Window Manager,
 /// the Controller or the Preview write to stderr:
@@ -73,6 +74,12 @@ void onRunMonarchAppStdErrMessage(String message, Logger logger_) {
       logger_.info('**ignored-severe** $message');
       return;
     }
+  }
+
+  var unableToUseRegex =
+      RegExp(r'.*object\.cc.*Unable to use class.*which is not loaded yet');
+  if (unableToUseRegex.hasMatch(message)) {
+    reload_crash.hadUnableToUseClassDartError = true;
   }
 
   // if the message is multi-line

--- a/cli/lib/src/task_runner/notifications.dart
+++ b/cli/lib/src/task_runner/notifications.dart
@@ -1,0 +1,14 @@
+import '../analytics/analytics.dart';
+import '../utils/standard_output.dart';
+import '../version_api/notification.dart';
+
+void showNotifications(List<Notification> notifications, StandardOutput stdout_,
+    Analytics analytics) {
+  for (var notification in notifications) {
+    stdout_.writeln();
+    stdout_.writeln('*' * 80);
+    stdout_.writeln(notification.message.trim());
+    stdout_.writeln('*' * 80);
+    analytics.notification_displayed(notification.id);
+  }
+}

--- a/cli/lib/src/task_runner/preview_api.dart
+++ b/cli/lib/src/task_runner/preview_api.dart
@@ -36,6 +36,14 @@ class PreviewApi with Log {
     return response.isSuccessful;
   }
 
+  /// Signals the platform code that the preview will restart.
+  /// Implemented on Windows.
+  /// Assumes [isAvailable] has returned true.
+  Future<void> willRestartPreview() async {
+    var client = await getClient();
+    await client!.willRestartPreview(Empty());
+  }
+
   /// Restars the preview window via platform code.
   /// Assumes [isAvailable] has returned true.
   Future<void> restartPreview() async {

--- a/cli/lib/src/task_runner/reload_crash.dart
+++ b/cli/lib/src/task_runner/reload_crash.dart
@@ -2,32 +2,26 @@
 /// - https://github.com/flutter/flutter/issues/120841
 /// - https://github.com/Dropsource/monarch/issues/72
 
+import '../version_api/notification.dart';
+
 bool hadHotReloadGrpcError = false;
 bool hadUnableToUseClassDartError = false;
 
-String knownIssue = '''
-
-*******************************************************************************
-
+Notification workaroundNotification =
+    Notification(id: 'reload-crash-workaround', message: '''
 You have hit a known Flutter issue. The issue is documented here:
   https://github.com/flutter/flutter/issues/120841
 
 The workaround is to run monarch with the hot-restart option:
   monarch run --reload hot-restart
+''');
 
-*******************************************************************************
-''';
-
-String maybeKnownIssue = '''
-
-*******************************************************************************
-
+Notification workaroundMaybeNotification =
+    Notification(id: 'reload-crash-workaround-maybe', message: '''
 You may have hit a known Flutter issue. The issue is documented here:
   https://github.com/flutter/flutter/issues/120841
 
 If you believe you hit the same issue, the workaround is to run monarch 
 with the hot-restart option:
   monarch run --reload hot-restart
-
-*******************************************************************************
-''';
+''');

--- a/cli/lib/src/task_runner/reload_crash.dart
+++ b/cli/lib/src/task_runner/reload_crash.dart
@@ -1,0 +1,33 @@
+/// Tracks hot reload crash documented here:
+/// - https://github.com/flutter/flutter/issues/120841
+/// - https://github.com/Dropsource/monarch/issues/72
+
+bool hadHotReloadGrpcError = false;
+bool hadUnableToUseClassDartError = false;
+
+String knownIssue = '''
+
+*******************************************************************************
+
+You have hit a known Flutter issue. The issue is documented here:
+  https://github.com/flutter/flutter/issues/120841
+
+The workaround is to run monarch with the hot-restart option:
+  monarch run --reload hot-restart
+
+*******************************************************************************
+''';
+
+String maybeKnownIssue = '''
+
+*******************************************************************************
+
+You may have hit a known Flutter issue. The issue is documented here:
+  https://github.com/flutter/flutter/issues/120841
+
+If you believe you hit the same issue, the workaround is to run monarch 
+with the hot-restart option:
+  monarch run --reload hot-restart
+
+*******************************************************************************
+''';

--- a/cli/lib/src/task_runner/reloaders.dart
+++ b/cli/lib/src/task_runner/reloaders.dart
@@ -42,7 +42,6 @@ class HotReloader extends Reloader {
         reload_crash.hadHotReloadGrpcError = true;
         log.severe('GrpcError during call to previewApi.hotReload', e, s);
         heartbeat.completeError();
-        stdout_.writeln('Request to hot-reload failed.');
       }
     } else {
       log.warning('Unable to hot reload. The preview_api is not available.');

--- a/cli/lib/src/task_runner/reloaders.dart
+++ b/cli/lib/src/task_runner/reloaders.dart
@@ -23,13 +23,13 @@ class HotReloader extends Reloader {
     this.stdout_,
   );
 
-  /// Calls hot-reload on the controller grpc server.
+  /// Calls hot-reload on the preview_api.
   /// It checks if the hot-reload request was successful.
   /// It does not regen or rebundle.
   @override
   Future<void> reload(Heartbeat heartbeat) async {
     if (await previewApi.isAvailable()) {
-      log.fine('Sending hotReload request to controller grpc client');
+      log.fine('Sending hotReload request to preview_api');
       var isSuccessful = await previewApi.hotReload();
       heartbeat.complete();
       if (!isSuccessful) {
@@ -77,7 +77,7 @@ class HotRestarter extends Reloader {
     }
 
     if (await previewApi.isAvailable()) {
-      log.fine('Sending restartPreview request to controller grpc client');
+      log.fine('Sending restartPreview request to preview_api');
       await previewApi.restartPreview();
     } else {
       log.warning('Unable to hot restart. The preview_api is not available.');

--- a/cli/lib/src/task_runner/task_runner.dart
+++ b/cli/lib/src/task_runner/task_runner.dart
@@ -25,6 +25,7 @@ import 'task_names.dart';
 import 'terminator.dart';
 import 'key_commands.dart';
 import 'tasks_managers.dart';
+import 'reload_crash.dart' as reload_crash;
 
 enum ReloadOption { hotReload, hotRestart, manual }
 
@@ -393,8 +394,18 @@ class TaskRunner extends LongRunningCli<CliExitCode> with Log {
       await Future.delayed(Duration(milliseconds: 50), () {
         var ctrlC =
             valueForPlatform(macos: '⌃C', windows: 'Ctrl+C', linux: 'Ctrl+C');
-        stdout_default
-            .writeln('\nMonarch app terminated. Press $ctrlC to exit CLI.');
+
+        if (reload_crash.hadHotReloadGrpcError) {
+          if (reload_crash.hadUnableToUseClassDartError) {
+            stdout_default.writeln(reload_crash.knownIssue);
+          } else {
+            stdout_default.writeln(reload_crash.maybeKnownIssue);
+          }
+          stdout_default.writeln('\nPress $ctrlC to exit CLI.');
+        } else {
+          stdout_default
+              .writeln('\nMonarch app terminated. Press $ctrlC to exit CLI.');
+        }
       });
     }
   }

--- a/cli/lib/src/task_runner/task_runner.dart
+++ b/cli/lib/src/task_runner/task_runner.dart
@@ -17,6 +17,7 @@ import '../utils/standard_output.dart';
 import 'attach_task.dart';
 import 'monarch_app_stdout.dart';
 import 'monarch_app_stderr.dart';
+import 'notifications.dart';
 import 'task.dart';
 import 'task_runner_exit_codes.dart';
 import 'process_task.dart';
@@ -397,9 +398,11 @@ class TaskRunner extends LongRunningCli<CliExitCode> with Log {
 
         if (reload_crash.hadHotReloadGrpcError) {
           if (reload_crash.hadUnableToUseClassDartError) {
-            stdout_default.writeln(reload_crash.knownIssue);
+            showNotifications([reload_crash.workaroundNotification],
+                stdout_default, analytics);
           } else {
-            stdout_default.writeln(reload_crash.maybeKnownIssue);
+            showNotifications([reload_crash.workaroundMaybeNotification],
+                stdout_default, analytics);
           }
           stdout_default.writeln('\nPress $ctrlC to exit CLI.');
         } else {

--- a/cli/lib/src/task_runner/task_runner.dart
+++ b/cli/lib/src/task_runner/task_runner.dart
@@ -468,6 +468,7 @@ class TaskRunner extends LongRunningCli<CliExitCode> with Log {
                   regenTask: _watchToRegenTask!,
                   buildPreviewBundleTask: _buildPreviewBundleTask!,
                   previewApi: previewApi,
+                  stdout_: stdout_default,
                 );
 
           _regenAndReloadManager!.manage();
@@ -515,6 +516,7 @@ class TaskRunner extends LongRunningCli<CliExitCode> with Log {
           generateTask: _generateStoriesTask!,
           bundleTask: _buildPreviewBundleTask!,
           previewApi: previewApi,
+          stdout_: stdout_default,
         ),
         helpKeyCommand,
         QuitKeyCommand()

--- a/cli/lib/src/task_runner/tasks_managers.dart
+++ b/cli/lib/src/task_runner/tasks_managers.dart
@@ -81,11 +81,13 @@ class RegenRebundleAndHotRestart extends TasksManager {
   final ProcessParentReadyTask regenTask;
   final ProcessTask buildPreviewBundleTask;
   final PreviewApi previewApi;
+  final StandardOutput stdout_;
 
   RegenRebundleAndHotRestart({
     required this.regenTask,
     required this.buildPreviewBundleTask,
     required this.previewApi,
+    required this.stdout_,
   });
 
   @override
@@ -124,7 +126,7 @@ class RegenRebundleAndHotRestart extends TasksManager {
   }
 
   void reload() async {
-    var reloader = HotRestarter(buildPreviewBundleTask, previewApi);
+    var reloader = HotRestarter(buildPreviewBundleTask, previewApi, stdout_);
     reloader.reload(heartbeat);
   }
 }

--- a/cli/pubspec.yaml
+++ b/cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: monarch_cli
 description: Command-line interface for Monarch binaries.
-version: 3.0.0
+version: 3.0.1
 publish_to: none
 
 environment:

--- a/cli/pubspec.yaml
+++ b/cli/pubspec.yaml
@@ -23,14 +23,10 @@ dependencies:
   monarch_utils: ^1.0.4
   monarch_http: ^1.2.0
   monarch_io_utils: ^1.3.0
-  monarch_grpc: ^2.1.0
+  monarch_grpc: ^2.2.0
 
 dev_dependencies:
   lints: ^2.0.1
   test: ^1.17.2
   mockito: ^5.0.7
   build_runner:
-
-dependency_overrides:
-  monarch_grpc:
-    path: ../packages/monarch_grpc

--- a/cli/pubspec.yaml
+++ b/cli/pubspec.yaml
@@ -30,3 +30,7 @@ dev_dependencies:
   test: ^1.17.2
   mockito: ^5.0.7
   build_runner:
+
+dependency_overrides:
+  monarch_grpc:
+    path: ../packages/monarch_grpc

--- a/packages/monarch_definitions/CHANGELOG.md
+++ b/packages/monarch_definitions/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.3.0 - 2023-02-20
+- Add method `monarch.willRestartPreview`
+
 ### 1.2.0 - 2022-10-27
 - Added definitions, mappers
 - Upgraded lints package

--- a/packages/monarch_definitions/lib/monarch_channels.dart
+++ b/packages/monarch_definitions/lib/monarch_channels.dart
@@ -21,6 +21,7 @@ class MonarchMethods {
   static const getState = 'monarch.getState';
   static const willClosePreview = 'monarch.willClosePreview';
   static const hotReload = 'monarch.hotReload';
+  static const willRestartPreview = 'monarch.willRestartPreview';
   static const restartPreview = 'monarch.restartPreview';
   static const previewVmServerUri = 'monarch.previewVmServerUri';
   static const userMessage = 'monarch.userMessage';

--- a/packages/monarch_definitions/pubspec.yaml
+++ b/packages/monarch_definitions/pubspec.yaml
@@ -1,6 +1,6 @@
 name: monarch_definitions
 description: Types and channel definitions for Monarch. Monarch is a tool for building Flutter widgets in isolation. It makes it easy to build, test and debug complex UIs.
-version: 1.2.0
+version: 1.3.0
 homepage: https://monarchapp.io
 repository: https://github.com/Dropsource/monarch
 issue_tracker: https://github.com/Dropsource/monarch/issues

--- a/packages/monarch_grpc/CHANGELOG.md
+++ b/packages/monarch_grpc/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 2.2.0 - 2023-02-20
+- WillRestartPreview rpc
+
 ### 2.1.0 - 2023-01-27
 - Linux support
 

--- a/packages/monarch_grpc/lib/src/generated/monarch_grpc.pb.dart
+++ b/packages/monarch_grpc/lib/src/generated/monarch_grpc.pb.dart
@@ -3,7 +3,7 @@
 //  source: monarch_grpc.proto
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
+// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
 
 import 'dart:core' as $core;
 

--- a/packages/monarch_grpc/lib/src/generated/monarch_grpc.pbenum.dart
+++ b/packages/monarch_grpc/lib/src/generated/monarch_grpc.pbenum.dart
@@ -3,5 +3,5 @@
 //  source: monarch_grpc.proto
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
+// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
 

--- a/packages/monarch_grpc/lib/src/generated/monarch_grpc.pbgrpc.dart
+++ b/packages/monarch_grpc/lib/src/generated/monarch_grpc.pbgrpc.dart
@@ -3,7 +3,7 @@
 //  source: monarch_grpc.proto
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
+// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
 
 import 'dart:async' as $async;
 
@@ -74,6 +74,10 @@ class MonarchPreviewApiClient extends $grpc.Client {
       '/monarch_grpc.MonarchPreviewApi/HotReload',
       ($0.Empty value) => value.writeToBuffer(),
       ($core.List<$core.int> value) => $0.ReloadResponse.fromBuffer(value));
+  static final _$willRestartPreview = $grpc.ClientMethod<$0.Empty, $0.Empty>(
+      '/monarch_grpc.MonarchPreviewApi/WillRestartPreview',
+      ($0.Empty value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.Empty.fromBuffer(value));
   static final _$restartPreview = $grpc.ClientMethod<$0.Empty, $0.Empty>(
       '/monarch_grpc.MonarchPreviewApi/RestartPreview',
       ($0.Empty value) => value.writeToBuffer(),
@@ -162,6 +166,11 @@ class MonarchPreviewApiClient extends $grpc.Client {
   $grpc.ResponseFuture<$0.ReloadResponse> hotReload($0.Empty request,
       {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$hotReload, request, options: options);
+  }
+
+  $grpc.ResponseFuture<$0.Empty> willRestartPreview($0.Empty request,
+      {$grpc.CallOptions? options}) {
+    return $createUnaryCall(_$willRestartPreview, request, options: options);
   }
 
   $grpc.ResponseFuture<$0.Empty> restartPreview($0.Empty request,
@@ -283,6 +292,13 @@ abstract class MonarchPreviewApiServiceBase extends $grpc.Service {
         ($core.List<$core.int> value) => $0.Empty.fromBuffer(value),
         ($0.ReloadResponse value) => value.writeToBuffer()));
     $addMethod($grpc.ServiceMethod<$0.Empty, $0.Empty>(
+        'WillRestartPreview',
+        willRestartPreview_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) => $0.Empty.fromBuffer(value),
+        ($0.Empty value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.Empty, $0.Empty>(
         'RestartPreview',
         restartPreview_Pre,
         false,
@@ -377,6 +393,11 @@ abstract class MonarchPreviewApiServiceBase extends $grpc.Service {
     return hotReload(call, await request);
   }
 
+  $async.Future<$0.Empty> willRestartPreview_Pre(
+      $grpc.ServiceCall call, $async.Future<$0.Empty> request) async {
+    return willRestartPreview(call, await request);
+  }
+
   $async.Future<$0.Empty> restartPreview_Pre(
       $grpc.ServiceCall call, $async.Future<$0.Empty> request) async {
     return restartPreview(call, await request);
@@ -420,6 +441,8 @@ abstract class MonarchPreviewApiServiceBase extends $grpc.Service {
   $async.Future<$0.Empty> toggleVisualDebugFlag(
       $grpc.ServiceCall call, $0.VisualDebugFlagInfo request);
   $async.Future<$0.ReloadResponse> hotReload(
+      $grpc.ServiceCall call, $0.Empty request);
+  $async.Future<$0.Empty> willRestartPreview(
       $grpc.ServiceCall call, $0.Empty request);
   $async.Future<$0.Empty> restartPreview(
       $grpc.ServiceCall call, $0.Empty request);

--- a/packages/monarch_grpc/lib/src/generated/monarch_grpc.pbjson.dart
+++ b/packages/monarch_grpc/lib/src/generated/monarch_grpc.pbjson.dart
@@ -3,7 +3,7 @@
 //  source: monarch_grpc.proto
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields,deprecated_member_use_from_same_package
+// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,deprecated_member_use_from_same_package,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
 
 import 'dart:core' as $core;
 import 'dart:convert' as $convert;

--- a/packages/monarch_grpc/protos/monarch_grpc.proto
+++ b/packages/monarch_grpc/protos/monarch_grpc.proto
@@ -19,6 +19,7 @@ service MonarchPreviewApi {
     rpc ToggleVisualDebugFlag(VisualDebugFlagInfo) returns (Empty) {}
 
     rpc HotReload(Empty) returns (ReloadResponse) {}
+    rpc WillRestartPreview(Empty) returns (Empty) {}
     rpc RestartPreview(Empty) returns (Empty) {}
     rpc LaunchDevTools(Empty) returns (Empty) {}
     rpc TrackUserSelection(KindInfo) returns (Empty) {}

--- a/packages/monarch_grpc/pubspec.yaml
+++ b/packages/monarch_grpc/pubspec.yaml
@@ -1,6 +1,6 @@
 name: monarch_grpc
 description: gRPC interfaces for Monarch. Monarch is a tool for building Flutter widgets in isolation. It makes it easy to build, test and debug complex UIs.
-version: 2.1.0
+version: 2.2.0
 homepage: https://monarchapp.io
 repository: https://github.com/Dropsource/monarch
 issue_tracker: https://github.com/Dropsource/monarch/issues

--- a/platform/windows/CHANGELOG.md
+++ b/platform/windows/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.3.0 - 2023-02-20
+- Support hot restart. Closes preview window on willRestartPreview
+  method call. Re-opens preview window on restartPreview method call.
+  
+
 ## 2.2.2 - 2022-12-13
 - Pass empty string to `FlutterEngine::Run` to workaround crash
   (https://github.com/flutter/flutter/issues/116753)

--- a/platform/windows/build_settings.yaml
+++ b/platform/windows/build_settings.yaml
@@ -2,7 +2,7 @@
 
 # Version of the Monarch Windows app. Avoid pre-releases until
 # we have tested that the Windows build works with pre-releases.
-version: 2.2.2
+version: 2.3.0
 
 # Relative path from gen\runner directory. Use double back-slashes.
 app_icon_path: ..\\..\\src\\resources\\monarch_app_icon.ico

--- a/platform/windows/src/channels.h
+++ b/platform/windows/src/channels.h
@@ -26,6 +26,7 @@ public:
 	void setUpCallForwarding();
 	void sendWillClosePreview();
 	void unregisterMethodCallHandlers();
+	void registerRestartPreviewMethodCallHandler();
 	void restartPreviewChannel(flutter::BinaryMessenger* previewMessenger);
 
 	std::unique_ptr<flutter::MethodChannel<EncodableValue>> previewApiChannel;
@@ -46,6 +47,7 @@ namespace MonarchMethods
 	const std::string setDockSide = "monarch.setDockSide";
 	const std::string getState = "monarch.getState";
 	const std::string screenChanged = "monarch.screenChanged";
+	const std::string willRestartPreview = "monarch.willRestartPreview";
 	const std::string restartPreview = "monarch.restartPreview";
 	const std::string willClosePreview = "monarch.willClosePreview";
 	const std::string terminatePreview = "monarch.terminatePreview";

--- a/platform/windows/src/monarch_window.cpp
+++ b/platform/windows/src/monarch_window.cpp
@@ -364,6 +364,7 @@ LRESULT PreviewWindow::MessageHandler(
 	{
 		// The controller sent its window handle, store it.
 		_controllerWindowHandle = HWND(wparam);
+		windowManager->controllerWindowHandle = HWND(wparam);
 	}
 	else if (message == MonarchWindowMessages::controllerMoveMessage)
 	{

--- a/platform/windows/src/window_manager.cpp
+++ b/platform/windows/src/window_manager.cpp
@@ -228,16 +228,18 @@ void PreviewWindowManager::setDocking(MonarchState state)
 	}
 }
 
-void PreviewWindowManager::restartPreviewWindow()
+void PreviewWindowManager::willRestartPreviewWindow()
 {
 	_channels->sendWillClosePreview();
 	_channels->unregisterMethodCallHandlers();
-
-	auto controllerWindowHandle = _previewWindow->getControllerWindowHandle();
+	_channels->registerRestartPreviewMethodCallHandler();
 
 	_previewWindow->SetQuitOnClose(false);
 	_previewWindow->Destroy();
+}
 
+void PreviewWindowManager::restartPreviewWindow()
+{
 	flutter::DartProject previewProject(to_wstring(_previewWindowBundlePath));
 	std::vector<std::string> previewArguments = { _defaultLogLevelString };
 	previewProject.set_dart_entrypoint_arguments(previewArguments);

--- a/platform/windows/src/window_manager.h
+++ b/platform/windows/src/window_manager.h
@@ -32,7 +32,6 @@ private:
 	std::string _projectName;
 
 	std::unique_ptr<ControllerWindow> _controllerWindow;
-	HWND _previewWindowHandle;
 
 	void _showAndSetUpControllerWindow(WindowInfo windowInfo);
 };
@@ -47,6 +46,7 @@ public:
 		std::string cliGrpcServerPort);
 	~PreviewWindowManager();
 
+	HWND controllerWindowHandle;
 	DockSide selectedDockSide;
 
 	void launchPreviewWindow();
@@ -57,6 +57,8 @@ public:
 	void resizePreviewWindow(MonarchState state);
 	void setDocking();
 	void setDocking(MonarchState state);
+	
+	void willRestartPreviewWindow();
 	void restartPreviewWindow();
 	void terminate();
 
@@ -68,7 +70,6 @@ private:
 
 	std::unique_ptr<PreviewWindow> _previewWindow;
 	std::unique_ptr<PreviewApiRunner> _previewApi;
-	HWND _controllerWindowHandle;
 
 	std::unique_ptr<Channels> _channels;
 

--- a/preview_api/CHANGELOG.md
+++ b/preview_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.0 - 2023-02-20
+- Adds willRestartPreview api function, which sends channel method with same name, 
+  which is handled by Windows platform.
+
 ## 2.1.0 - 2023-01-30
 - Linux support, use latest monarch_* dependencies
 

--- a/preview_api/CHANGELOG.md
+++ b/preview_api/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.2.0 - 2023-02-20
 - Adds willRestartPreview api function, which sends channel method with same name, 
   which is handled by Windows platform.
+- Use monarch_grpc 2.2.0 and monarch_definitions 1.3.0
 
 ## 2.1.0 - 2023-01-30
 - Linux support, use latest monarch_* dependencies

--- a/preview_api/lib/src/abstract_channel_methods_sender.dart
+++ b/preview_api/lib/src/abstract_channel_methods_sender.dart
@@ -23,6 +23,8 @@ abstract class AbstractChannelMethodsSender {
 
   Future<bool> hotReload();
 
+  void willRestartPreview();
+
   void restartPreview();
 
   void terminatePreview();

--- a/preview_api/lib/src/channel_methods_sender.dart
+++ b/preview_api/lib/src/channel_methods_sender.dart
@@ -87,4 +87,9 @@ class ChannelMethodsSender with Log implements AbstractChannelMethodsSender {
   void terminatePreview() {
     _invokeMonarchChannelMethod(MonarchMethods.terminatePreview);
   }
+  
+  @override
+  void willRestartPreview() {
+    _invokeMonarchChannelMethod(MonarchMethods.willRestartPreview);
+  }
 }

--- a/preview_api/lib/src/channel_methods_sender.dart
+++ b/preview_api/lib/src/channel_methods_sender.dart
@@ -87,7 +87,7 @@ class ChannelMethodsSender with Log implements AbstractChannelMethodsSender {
   void terminatePreview() {
     _invokeMonarchChannelMethod(MonarchMethods.terminatePreview);
   }
-  
+
   @override
   void willRestartPreview() {
     _invokeMonarchChannelMethod(MonarchMethods.willRestartPreview);

--- a/preview_api/lib/src/preview_api_service.dart
+++ b/preview_api/lib/src/preview_api_service.dart
@@ -119,6 +119,12 @@ class PreviewApiService extends MonarchPreviewApiServiceBase {
   }
 
   @override
+  Future<Empty> willRestartPreview(ServiceCall call, Empty request) {
+    channelMethodsSender.willRestartPreview();
+    return Future.value(Empty());
+  }
+
+  @override
   Future<Empty> restartPreview(ServiceCall call, Empty request) {
     channelMethodsSender.restartPreview();
     return Future.value(Empty());

--- a/preview_api/pubspec.yaml
+++ b/preview_api/pubspec.yaml
@@ -12,8 +12,8 @@ dependencies:
     sdk: flutter
   monarch_utils: ^1.0.0
   monarch_io_utils: ^1.3.0
-  monarch_definitions: ^1.2.0
-  monarch_grpc: ^2.1.0
+  monarch_definitions: ^1.3.0
+  monarch_grpc: ^2.2.0
   grpc: ^3.0.2
 
 dev_dependencies:
@@ -22,9 +22,3 @@ dev_dependencies:
   flutter_lints: ^2.0.1
 
 flutter:
-
-dependency_overrides:
-  monarch_grpc:
-    path: ../packages/monarch_grpc
-  monarch_definitions:
-    path: ../packages/monarch_definitions

--- a/preview_api/pubspec.yaml
+++ b/preview_api/pubspec.yaml
@@ -1,7 +1,7 @@
 name: preview_api
 description: The Monarch Preview API
 publish_to: 'none'
-version: 2.1.0
+version: 2.2.0
 
 environment:
   sdk: '>=2.16.1 <3.0.0'

--- a/preview_api/pubspec.yaml
+++ b/preview_api/pubspec.yaml
@@ -22,3 +22,9 @@ dev_dependencies:
   flutter_lints: ^2.0.1
 
 flutter:
+
+dependency_overrides:
+  monarch_grpc:
+    path: ../packages/monarch_grpc
+  monarch_definitions:
+    path: ../packages/monarch_definitions


### PR DESCRIPTION
### Detect hot reload crash and notify user of workaround
- Handle grpc error during hot reload request
- Detect "Unable to use class...which is not loaded yet" from monarch-app stderr
- Notify user of workaround
- Use latest versions of package monarch_grpc, monarch_definitions

Since the workaround is to do hot-restart instead of hot-reload, this PR fixes #56 (hot restart on Windows).

### Fix hot restart (on Windows)
The Window file system doesn't let us copy the new bundle while it is still open in the preview window. Thus, this PR closes the preview window before re-bundling. After the bundling is done, it will re-open the preview window with the new bundle.
- Implemented willRestartPreview so Windows C++ code can cleanly close preview window before we bundle
- Changed restartPreview to handle the new process
- Required changes to cli, monarch_definitions, monarch_grpc, windows, preview_api
- Inform user that preview window will re-open
- Published new versions of packages monarch_definitions and monarch_grpc to support willRestartPreview flow.
