### PR TITLE
monarch package: Set upper flutter sdk version as 3.8.0-0.0.pre

### DIFF
--- a/packages/monarch/CHANGELOG.md
+++ b/packages/monarch/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 3.0.1 - 2023-02-23
+- Set upper flutter sdk version as 3.8.0-0.0.pre. This version of Flutter
+  introduces a new API for WidgetsBinding which is not compatible with this
+  version of the monarch package. 
+- The monarch package version 3.0.x will support flutter versions prior to 
+  3.8.0-0.0.pre. 
+- The monarch package version 3.3 and above will support flutter sdk versions 
+  greater than or equal to 3.8.0-0.0.pre.
+- Update vm_service dependency to 11.1.0
+
 ## 3.0.0 - 2022-11-14
 - Releasing monarch package 3.0.0 compatible with Monarch 2.x and Flutter 3.x
 

--- a/packages/monarch/pubspec.yaml
+++ b/packages/monarch/pubspec.yaml
@@ -1,6 +1,6 @@
 name: monarch
 description: Code generator for Monarch. Monarch is a tool for building Flutter widgets in isolation. It makes it easy to build, test and debug complex UIs.
-version: 3.0.0
+version: 3.0.1
 homepage: https://monarchapp.io
 repository: https://github.com/Dropsource/monarch
 issue_tracker: https://github.com/Dropsource/monarch/issues
@@ -9,7 +9,7 @@ documentation: https://monarchapp.io/docs/introduction
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
-  flutter: '>=2.12.0-4.1.pre'
+  flutter: '>=2.12.0-4.1.pre <3.8.0-0.0.pre'
 
 dependencies:
   flutter:
@@ -25,7 +25,7 @@ dependencies:
   glob: ^2.0.1
   analyzer: ^5.2.0
   path: ^1.8.0
-  vm_service: ^9.4.0
+  vm_service: ^11.1.0
   meta: ^1.3.0
   stack_trace: ^1.10.0
   flutter_test:


### PR DESCRIPTION
- Set upper flutter sdk version as 3.8.0-0.0.pre. This version of Flutter introduces a new API for WidgetsBinding which is not compatible with this version of the monarch package.
- The monarch package version 3.0.x will support flutter versions prior to 3.8.0-0.0.pre.
- The monarch package version 3.3 and above will support flutter sdk versions greater than or equal to 3.8.0-0.0.pre.
- Update vm_service dependency to 11.1.0