### PR TITLE
Support Flutter 3.10

### DIFF
--- a/cli/lib/src/config/context_info.dart
+++ b/cli/lib/src/config/context_info.dart
@@ -271,7 +271,7 @@ class ContextInfo with Log {
         log.warning(
             '"cmake --version" command did not exit successfully, got exit code: ${result.exitCode}');
       }
-    } catch (e, s) {
+    } catch (_) {
       log.warning('could not read CMake version');
     }
   }

--- a/packages/monarch/CHANGELOG.md
+++ b/packages/monarch/CHANGELOG.md
@@ -1,6 +1,16 @@
+
+## 3.4.0 - 2023-04-25
+- Faster code generation
+- Update vm_service dependency to `>=9.4.0`
+- Compatible with Flutter 3.8 or greater
+
+## 3.3.0 - 2023-02-24
+- Compatible with Flutter 3.8 or greater
+
 ## 3.1.0 - 2023-04-20
 - Faster code generation
 - Update vm_service dependency to `>=9.4.0`
+- Compatible with Flutter 3.7
 
 ## 3.0.1 - 2023-02-24
 - Flutter sdk version 3.8.0-0.0.pre

--- a/packages/monarch/CHANGELOG.md
+++ b/packages/monarch/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.5.0 - 2023-05-10
+- MonarchBinding now uses TestPlatformDispatcher instead of deprecated TestWindow
+- The change above was introduced in Flutter 3.9
+- Compatible with Flutter 3.9 or greater
 
 ## 3.4.0 - 2023-04-25
 - Faster code generation

--- a/packages/monarch/lib/src/preview/monarch_binding.dart
+++ b/packages/monarch/lib/src/preview/monarch_binding.dart
@@ -9,7 +9,6 @@ import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 
 import 'package:flutter_test/flutter_test.dart';
-import 'dart:ui' as ui;
 
 import 'package:monarch_definitions/monarch_definitions.dart';
 

--- a/packages/monarch/lib/src/preview/monarch_binding.dart
+++ b/packages/monarch/lib/src/preview/monarch_binding.dart
@@ -26,6 +26,11 @@ class MonarchBinding extends BindingBase
         SemanticsBinding,
         RendererBinding,
         WidgetsBinding {
+  MonarchBinding()
+      : platformDispatcher = TestPlatformDispatcher(
+          platformDispatcher: PlatformDispatcher.instance,
+        );
+
   @override
   void initInstances() {
     super.initInstances();
@@ -49,17 +54,17 @@ class MonarchBinding extends BindingBase
   }
 
   @override
-  TestWindow get window => _window;
-  final _window = TestWindow(window: ui.window);
+  final TestPlatformDispatcher platformDispatcher;
 
   void _onDeviceChanged(DeviceDefinition device) {
-    window.physicalSizeTestValue = Size(
-        device.logicalResolution.width * window.devicePixelRatio,
-        device.logicalResolution.height * window.devicePixelRatio);
+    var view = platformDispatcher.implicitView!;
+    view.physicalSize = Size(
+        device.logicalResolution.width * view.devicePixelRatio,
+        device.logicalResolution.height * view.devicePixelRatio);
   }
 
   void _onTextScaleFactorChanged(double factor) {
-    window.platformDispatcher.textScaleFactorTestValue = factor;
+    platformDispatcher.textScaleFactorTestValue = factor;
   }
 
   final _willReassembleStreamController = StreamController<void>.broadcast();

--- a/packages/monarch/lib/src/preview/start_monarch_preview.dart
+++ b/packages/monarch/lib/src/preview/start_monarch_preview.dart
@@ -39,7 +39,8 @@ void _startMonarchPreview(ProjectData Function() getProjectData) async {
   });
 
   Timer.run(() {
-    monarchBinding.attachRootWidget(MonarchPreview());
+    monarchBinding
+        .attachRootWidget(monarchBinding.wrapWithDefaultView(MonarchPreview()));
   });
   monarchBinding.scheduleWarmUpFrame();
 

--- a/packages/monarch/pubspec.yaml
+++ b/packages/monarch/pubspec.yaml
@@ -1,6 +1,6 @@
 name: monarch
 description: Code generator for Monarch. Monarch is a tool for building Flutter widgets in isolation. It makes it easy to build, test and debug complex UIs.
-version: 3.4.0
+version: 3.5.0
 homepage: https://monarchapp.io
 repository: https://github.com/Dropsource/monarch
 issue_tracker: https://github.com/Dropsource/monarch/issues
@@ -9,7 +9,7 @@ documentation: https://monarchapp.io/docs/introduction
 
 environment:
   sdk: '>=2.12.0 <4.0.0'
-  flutter: '>=3.8.0-0.0.pre'
+  flutter: '>=3.9.0-0.1.pre'
 
 dependencies:
   flutter:

--- a/packages/monarch/pubspec.yaml
+++ b/packages/monarch/pubspec.yaml
@@ -1,6 +1,6 @@
 name: monarch
 description: Code generator for Monarch. Monarch is a tool for building Flutter widgets in isolation. It makes it easy to build, test and debug complex UIs.
-version: 3.1.0
+version: 3.4.0
 homepage: https://monarchapp.io
 repository: https://github.com/Dropsource/monarch
 issue_tracker: https://github.com/Dropsource/monarch/issues
@@ -9,7 +9,7 @@ documentation: https://monarchapp.io/docs/introduction
 
 environment:
   sdk: '>=2.12.0 <4.0.0'
-  flutter: '>=2.12.0-4.1.pre'
+  flutter: '>=3.8.0-0.0.pre'
 
 dependencies:
   flutter:

--- a/platform/macos/monarch_macos/AppDelegate.swift
+++ b/platform/macos/monarch_macos/AppDelegate.swift
@@ -6,14 +6,12 @@
 //
 
 import Cocoa
+import FlutterMacOS
 
 @main
-class AppDelegate: NSObject, NSApplicationDelegate {
+class AppDelegate: FlutterAppDelegate {
 
-    
-
-
-    func applicationDidFinishLaunching(_ aNotification: Notification) {
+    override func applicationDidFinishLaunching(_ aNotification: Notification) {
         // disables buffering so calls to println are flushed automatically
         // setbuf(__stdoutp, nil);
         // https://stackoverflow.com/questions/24171362/swift-how-to-flush-stdout-after-println
@@ -21,19 +19,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let windowManager = WindowManager.init()
         windowManager.launchWindows()
     }
-
-    func applicationWillTerminate(_ aNotification: Notification) {
-        
-    }
     
-    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+    override func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
         return true
     }
-
-    func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {
-        return true
-    }
-
 
 }
 


### PR DESCRIPTION
monarch package changes:
- Merge monarch-package-3.4 branch onto main. Branch monarch-package-3.4 had changes compatible with Flutter 3.8.
- MonarchBinding now uses TestPlatformDispatcher instead of deprecated TestWindow, which was introduced in Flutter 3.9
- Both Flutter 3.8 and 3.9 are now stable via Flutter 3.10.

monarch macos changes:
- Derive from FlutterAppDelegate to avoid crash in Flutter 3.10. See https://github.com/flutter/flutter/issues/124829


