### PR TITLE
controller: support for non-English user.

### DIFF
--- a/controller/lib/data/stories.dart
+++ b/controller/lib/data/stories.dart
@@ -1,30 +1,32 @@
 import 'package:flutter/foundation.dart';
 import 'package:monarch_definitions/monarch_definitions.dart';
 
+final notAscii = RegExp(r'[^ -~]');
+
 class StoryGroup {
-  final String groupName;
+  final String _groupName;
   final List<StoryId> stories;
   final String groupKey;
 
+  String get groupName => notAscii.hasMatch(_groupName) ? _groupName.replaceFirst('_stories', '') :  _groupName;
+
   StoryGroup({
-    required this.groupName,
+    required String groupName,
     required this.stories,
     required this.groupKey,
-  });
+  }) : _groupName = groupName;
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      other is StoryGroup &&
-          groupName == other.groupName &&
-          listEquals(stories, other.stories);
+      other is StoryGroup && _groupName == other._groupName && listEquals(stories, other.stories);
 
   @override
-  int get hashCode => groupName.hashCode ^ stories.hashCode;
+  int get hashCode => _groupName.hashCode ^ stories.hashCode;
 
   StoryGroup copyWith({List<StoryId>? stories}) {
     return StoryGroup(
-      groupName: groupName,
+      groupName: _groupName,
       stories: stories ?? this.stories,
       groupKey: groupKey,
     );

--- a/packages/monarch/lib/src/builders/meta_stories_builder.dart
+++ b/packages/monarch/lib/src/builders/meta_stories_builder.dart
@@ -30,6 +30,11 @@ class MetaStoriesBuilder implements Builder {
         continue;
       }
 
+      String? metaName;
+      var pragma = declaration.metadata.where((annotation) => annotation.name.name == 'pragma');
+      if (pragma.isNotEmpty) {
+        metaName = pragma.first.arguments?.arguments.first.toString();
+      }
       var functionName = declaration.name.lexeme;
       var returnType = declaration.returnType;
       var parameters = declaration.functionExpression.parameters;
@@ -73,8 +78,8 @@ class MetaStoriesBuilder implements Builder {
       var storyNameInSingleQuotes = "'$storyName'";
       log.fine('Found potential story `$returnTypeName $storyName()`.');
 
-      storiesNames.add(storyNameInSingleQuotes);
-      storiesMap[storyNameInSingleQuotes] = storyName;
+      storiesNames.add(metaName ?? storyNameInSingleQuotes);
+      storiesMap[metaName ?? storyNameInSingleQuotes] = storyName;
     }
 
     final pathToStoriesFile = getImportUriOrRelativePath(buildStep.inputId);


### PR DESCRIPTION
First of all, thanks for this wonderful tool.

This pr optimizes the experience of non-English users, including the following two optimizations:
1. Use @pragma('some non-Eng name like 测试') to name a story
2. Remove the '_stories' suffix from the story tree when using stories files containing non-English characters to name
Optimization effect:
![image](https://github.com/Dropsource/monarch/assets/19624835/ffdc8cd9-b6d6-4f89-b8ad-a8672cdbd3af)
