### PR TITLE
macos: conditional use of FlutterAppDelegate lifecycle methods 

### DIFF
--- a/platform/macos/monarch_macos/WindowManager.swift
+++ b/platform/macos/monarch_macos/WindowManager.swift
@@ -46,6 +46,9 @@ class WindowManager {
 #if USE_FLUTTER_APP_DELEGATE
         logger.info("Using swift compilation condition (i.e. preprocessor directive): USE_FLUTTER_APP_DELEGATE")
 #endif
+#if USE_APPLICATION_LIFECYCLE_METHODS
+        logger.info("Using swift compilation condition (i.e. preprocessor directive): USE_APPLICATION_LIFECYCLE_METHODS")
+#endif
          self.checkCommandLineArguments()
     }
     

--- a/platform/macos/monarch_macos/WindowManager.swift
+++ b/platform/macos/monarch_macos/WindowManager.swift
@@ -145,7 +145,7 @@ class WindowManager {
         _tearDownObservers()
         channels!.sendWillClosePreview()
         previewViewController!.engine.shutDownEngine()
-#if USE_FLUTTER_APP_DELEGATE
+#if USE_FLUTTER_APP_DELEGATE && USE_APPLICATION_LIFECYCLE_METHODS
         flutterAppDelegate.removeApplicationLifecycleDelegate(previewViewController!.engine)
 #endif
         previewWindow!.close()

--- a/tools/build_platform.dart
+++ b/tools/build_platform.dart
@@ -88,15 +88,20 @@ Building $monarch_macos with xcodebuild. Will output to:
   /// In flutter version 3.14.0-0.1.pre, the flutter team fixed an issue
   /// in the flutter engine. As a result, we don't have to use FlutterAppDelegate
   /// anymore. Monarch macOS works better if we don't use FlutterAppDelegate.
-  /// 
+  ///
   /// See monarch PR: https://github.com/Dropsource/monarch/pull/124
   /// See flutter PR: https://github.com/flutter/flutter/issues/124829
   var flutterVersion = pub.Version.parse(get_flutter_version(flutter_sdk));
   var flutterVersionWithFlutterAppDelegateChange =
       pub.Version(3, 14, 0, pre: '0.1.pre');
+  var flutterVersionWithApplicationLifecycleMethods =
+      pub.Version(3, 11, 0, pre: '17.0.pre');
 
   var useFlutterAppDelegate =
       flutterVersion < flutterVersionWithFlutterAppDelegateChange;
+
+  var useApplicationLifecycleMethods =
+      flutterVersion >= flutterVersionWithApplicationLifecycleMethods;
 
   result = Process.runSync(
       'xcodebuild',
@@ -106,7 +111,9 @@ Building $monarch_macos with xcodebuild. Will output to:
         'CONFIGURATION_BUILD_DIR=$out_ui_flutter_id',
         'build',
         if (useFlutterAppDelegate)
-          'SWIFT_ACTIVE_COMPILATION_CONDITIONS=USE_FLUTTER_APP_DELEGATE'
+          'SWIFT_ACTIVE_COMPILATION_CONDITIONS=USE_FLUTTER_APP_DELEGATE',
+        if (useFlutterAppDelegate && useApplicationLifecycleMethods)
+          'SWIFT_ACTIVE_COMPILATION_CONDITIONS=USE_FLUTTER_APP_DELEGATE USE_APPLICATION_LIFECYCLE_METHODS'
       ],
       workingDirectory: repo_paths.platform_macos);
   utils.exitIfNeeded(result, 'Error running xcodebuild');

--- a/tools/build_platform.dart
+++ b/tools/build_platform.dart
@@ -84,13 +84,20 @@ Building $monarch_macos with xcodebuild. Will output to:
 
   /// The Flutter macOS API changed between versions. Here we use preprocessor
   /// directives to compile our code with different Flutter versions.
+  /// 
+  /// In flutter version 3.11.0-17.0.pre, the flutter team introduced 
+  /// FlutterAppDelegate lifecycle methods which is when the embedder error may 
+  /// have started. Also, we have to use the lifecycle methods to avoid the embedder error.
+  /// However, those methods are only available after the flutter version above.
+  /// - https://github.com/flutter/engine/pull/42418  
+  /// - https://github.com/Dropsource/monarch/pull/127
   ///
   /// In flutter version 3.14.0-0.1.pre, the flutter team fixed an issue
   /// in the flutter engine. As a result, we don't have to use FlutterAppDelegate
   /// anymore. Monarch macOS works better if we don't use FlutterAppDelegate.
-  ///
-  /// See monarch PR: https://github.com/Dropsource/monarch/pull/124
-  /// See flutter PR: https://github.com/flutter/flutter/issues/124829
+  /// - https://github.com/flutter/flutter/issues/124829
+  /// - https://github.com/flutter/engine/pull/43425
+  /// - https://github.com/Dropsource/monarch/pull/124
   var flutterVersion = pub.Version.parse(get_flutter_version(flutter_sdk));
   var flutterVersionWithFlutterAppDelegateChange =
       pub.Version(3, 14, 0, pre: '0.1.pre');


### PR DESCRIPTION
- conditional use of FlutterAppDelegate lifecycle methods using preprocessor directive
- Lifecycle methods, like `FlutterAppDelegate.removeApplicationLifecycleDelegate`, were introduced in Flutter SDK version 3.11.0-17.0.pre
- Monarch macOS code before that version should not use `FlutterAppDelegate.removeApplicationLifecycleDelegate`