### PR TITLE
Material 3 Tweaks

### DIFF
--- a/controller/CHANGELOG.md
+++ b/controller/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.4.1 - 2023-11-02
+- Use point versions for monarch_* packages.
+
 ## 1.4.0 - 2023-10-23
 - Handle `FlutterError.onError` to log controller flutter errors to stdout
 - Use latest monarch dependencies: monarch_definitions ^1.5.0, monarch_annotations ^1.0.4.

--- a/controller/lib/default_theme.dart
+++ b/controller/lib/default_theme.dart
@@ -15,7 +15,7 @@ const Color primaryButtonBackground = Color(0xFF2a2d52);
 const Color blue = Color(0xFF2D407F);
 const Color searchHighlightColor = Colors.amber;
 
-@MonarchTheme('Default Theme', isDefault: true)
+@MonarchTheme('Default Theme')
 ThemeData get theme => StockholmThemeData.dark().copyWith(
       primaryColor: blue,
       splashColor: Colors.transparent,

--- a/controller/pubspec.yaml
+++ b/controller/pubspec.yaml
@@ -3,7 +3,7 @@ description: Monarch Controller UI
 
 publish_to: 'none'
 
-version: 1.4.0
+version: 1.4.1
 
 environment:
   sdk: '>=2.16.1 <3.0.0'
@@ -17,12 +17,12 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   intl: any
-  monarch_annotations: ^1.0.4
-  monarch_definitions: ^1.5.0
-  monarch_io_utils: ^1.3.0
-  monarch_utils: ^1.1.0
+  monarch_annotations: 1.0.4
+  monarch_definitions: 1.5.1
+  monarch_io_utils: 1.3.0
+  monarch_utils: 1.1.0
   grpc: ^3.2.4
-  monarch_grpc: ^2.3.1
+  monarch_grpc: 2.3.1
   stockholm:
     git:
       url: https://github.com/serverpod/stockholm/

--- a/packages/monarch_definitions/CHANGELOG.md
+++ b/packages/monarch_definitions/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.5.1
+2023-08-25
+- Rollback Material 3 standard themes.
+
 ### 1.5.0 
 2023-08-23
 - Add Material 3 standard themes.

--- a/packages/monarch_definitions/lib/src/meta_theme_definition.dart
+++ b/packages/monarch_definitions/lib/src/meta_theme_definition.dart
@@ -22,8 +22,8 @@ const defaultThemeDefinition = materialLightThemeDefinition;
 const standardMetaThemeDefinitions = [
   materialLightThemeDefinition,
   materialDarkThemeDefinition,
-  material3LightThemeDefinition,
-  material3DarkThemeDefinition,
+  // material3LightThemeDefinition,
+  // material3DarkThemeDefinition,
 ];
 
 class MetaThemeDefinition {

--- a/packages/monarch_definitions/pubspec.yaml
+++ b/packages/monarch_definitions/pubspec.yaml
@@ -1,13 +1,13 @@
 name: monarch_definitions
 description: Types and channel definitions for Monarch. Monarch is a tool for building Flutter widgets in isolation. It makes it easy to build, test and debug complex UIs.
-version: 1.5.0
+version: 1.5.1
 homepage: https://monarchapp.io
 repository: https://github.com/Dropsource/monarch
 issue_tracker: https://github.com/Dropsource/monarch/issues
 documentation: https://monarchapp.io/docs/introduction
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.12.0 <4.0.0'
 
 dependencies:
 

--- a/preview_api/CHANGELOG.md
+++ b/preview_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.1 - 2023-11-02
+- Use point versions for monarch_* packages.
+- Using monarch_definitions `1.5.1` which rolls back Material 3 standard themes.
+
 ## 2.4.0 - 2023-10-23
 - Use monarch_definitions `^1.5.0` which contains new Material 3 standard themes.
 

--- a/preview_api/pubspec.yaml
+++ b/preview_api/pubspec.yaml
@@ -1,7 +1,7 @@
 name: preview_api
 description: The Monarch Preview API
 publish_to: 'none'
-version: 2.4.0
+version: 2.4.1
 
 environment:
   sdk: '>=2.16.1 <3.0.0'
@@ -10,10 +10,10 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  monarch_utils: ^1.0.0
-  monarch_io_utils: ^1.3.0
-  monarch_definitions: ^1.5.0
-  monarch_grpc: ^2.3.1
+  monarch_utils: 1.1.0
+  monarch_io_utils: 1.3.0
+  monarch_definitions: 1.5.1
+  monarch_grpc: 2.3.1
   grpc: ^3.2.4
 
 dev_dependencies:


### PR DESCRIPTION
- monarch_definitions: Rollback Material 3 standard themes until next release
- controller, preview_api: use point versions for `monarch_*` dependencies to make sure new monarch ui binaries of new flutter versions use the same `monarch_*` dependencies as the existing monarch ui binaries of existing flutter versions.