### PR TITLE
monarch package: Support Flutter 3.17

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
         with:
-          channel: 'stable' # or: 'beta', 'dev' or 'master'
+          channel: 'beta' # or: 'beta', 'dev' or 'master'
       - run: flutter --version
 
       - name: Install dependencies

--- a/packages/monarch/CHANGELOG.md
+++ b/packages/monarch/CHANGELOG.md
@@ -1,8 +1,11 @@
 ### 3.8.0
 2023-11-17
 - Support Flutter 3.17.0-0.0.pre, or greater, which pins vm_service dependency to `13.0.0`.
-- Update vm_service dependency to `>=9.4.0 <14.0.0`
-- Update lints dependency to `^3.0.0`
+- Update sdk min to `3.2.0`.
+- Update vm_service dependency to `>=9.4.0 <14.0.0`.
+- Update lints dependency to `^3.0.0`.
+- Use `Service.getIsolateId` instead of deprecated `Service.getIsolateID`.
+- Use super initializer `super.key`.
 
 ### 3.7.0
 2023-10-23

--- a/packages/monarch/CHANGELOG.md
+++ b/packages/monarch/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 3.8.0
+2023-11-17
+- Support Flutter 3.17.0-0.0.pre, or greater, which pins vm_service dependency to `13.0.0`.
+- Update vm_service dependency to `>=9.4.0 <14.0.0`
+- Update lints dependency to `^3.0.0`
+
 ### 3.7.0
 2023-10-23
 - Add Material 3 standard themes objects.

--- a/packages/monarch/lib/src/preview/monarch_preview.dart
+++ b/packages/monarch/lib/src/preview/monarch_preview.dart
@@ -73,9 +73,12 @@ class MonarchMaterialApp extends StatelessWidget {
   final Locale? locale;
   final Widget home;
 
-  MonarchMaterialApp(
-      {Key? key, required this.scale, required this.locale, required this.home})
-      : super(key: key);
+  MonarchMaterialApp({
+    super.key,
+    required this.scale,
+    required this.locale,
+    required this.home,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/packages/monarch/lib/src/preview/vm_service_client.dart
+++ b/packages/monarch/lib/src/preview/vm_service_client.dart
@@ -51,7 +51,7 @@ class VmServiceClient with Log {
     _client = await vmServiceConnectUri(webSocketUri, log: VmServiceLog());
     log.fine('Connected to vm service socket $webSocketUri');
     _isDisconnected = false;
-    _isolateId = developer.Service.getIsolateID(Isolate.current);
+    _isolateId = developer.Service.getIsolateId(Isolate.current);
     log.fine('Got isolateId=$_isolateId');
 
     _onClientDone();

--- a/packages/monarch/pubspec.yaml
+++ b/packages/monarch/pubspec.yaml
@@ -1,6 +1,6 @@
 name: monarch
 description: Code generator for Monarch. Monarch is a tool for building Flutter widgets in isolation. It makes it easy to build, test and debug complex UIs.
-version: 3.7.0
+version: 3.8.0
 homepage: https://monarchapp.io
 repository: https://github.com/Dropsource/monarch
 issue_tracker: https://github.com/Dropsource/monarch/issues
@@ -23,7 +23,7 @@ screenshots:
 
 environment:
   sdk: '>=2.12.0 <4.0.0'
-  flutter: '>=3.9.0-0.1.pre'
+  flutter: '>=3.17.0-0.0.pre'
 
 dependencies:
   flutter:
@@ -39,14 +39,14 @@ dependencies:
   glob: ^2.0.1
   analyzer: ^6.0.0
   path: ^1.8.0
-  vm_service: '>=9.4.0 <12.0.0'
+  vm_service: '>=9.4.0 <14.0.0'
   meta: ^1.3.0
   stack_trace: ^1.10.0
   flutter_test:
     sdk: flutter
 
 dev_dependencies: 
-  lints: ^2.0.0
+  lints: ^3.0.0
 
 flutter:
 

--- a/packages/monarch/pubspec.yaml
+++ b/packages/monarch/pubspec.yaml
@@ -22,7 +22,7 @@ screenshots:
     path: screenshots/04-find-bugs-fs8.png
 
 environment:
-  sdk: '>=2.12.0 <4.0.0'
+  sdk: '>=3.2.0 <4.0.0'
   flutter: '>=3.17.0-0.0.pre'
 
 dependencies:


### PR DESCRIPTION
- Support Flutter 3.17.0-0.0.pre, or greater, which pins vm_service dependency to `13.0.0`.
- Update vm_service dependency to `>=9.4.0 <14.0.0`
- Update lints dependency to `^3.0.0`