### PR TITLE
Reads devices from monarch.yaml

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.0 - 2025-03-10
+- Upgrades monarch_* package dependencies
+- Sets dart sdk constraint to ^3.2.0
+
 ## 3.0.5 - 2023-10-06
 - Use monarch_grpc 2.3.1
 - Detect performance overlay error and print solution

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 3.1.0 - 2025-03-10
 - Upgrades monarch_* package dependencies
 - Sets dart sdk constraint to ^3.2.0
+- monarch.yaml: Passes project directory path to platform window managers, 
+  i.e. monarch app processes
 
 ## 3.0.5 - 2023-10-06
 - Use monarch_grpc 2.3.1

--- a/cli/lib/src/config/project_config.dart
+++ b/cli/lib/src/config/project_config.dart
@@ -214,8 +214,7 @@ class ProjectConfig extends Validator with Log {
 }
 
 class TaskRunnerProjectConfig extends ProjectConfig {
-  TaskRunnerProjectConfig(Directory projectDirectory, InternalInfo internalInfo)
-      : super(projectDirectory, internalInfo);
+  TaskRunnerProjectConfig(super.projectDirectory, super.internalInfo);
 
   pub.Version? _monarchPackageVersion;
   pub.Version get monarchPackageVersion {

--- a/cli/lib/src/task_runner/attach_task.dart
+++ b/cli/lib/src/task_runner/attach_task.dart
@@ -143,7 +143,6 @@ class AttachTask with Log {
         stdout_default.writeln();
         stdout_default.writeln('Could not find DevTools URI.');
         break;
-      default:
     }
   }
 }

--- a/cli/lib/src/task_runner/process_task.dart
+++ b/cli/lib/src/task_runner/process_task.dart
@@ -192,25 +192,16 @@ class ProcessReadyTask extends ProcessTask implements ReadyTask {
   final bool expectReadyMessageOnce;
 
   ProcessReadyTask(
-      {required String taskName,
-      required String executable,
-      required List<String> arguments,
-      required String workingDirectory,
-      required Analytics analytics,
-      RegExp? logLevelRegex,
-      List<int>? successExitCodes,
-      OnStdErrMessageFn? onStdErrMessage,
+      {required super.taskName,
+      required super.executable,
+      required super.arguments,
+      required super.workingDirectory,
+      required super.analytics,
+      super.logLevelRegex,
+      super.successExitCodes,
+      super.onStdErrMessage,
       required this.readyMessage,
-      this.expectReadyMessageOnce = true})
-      : super(
-            taskName: taskName,
-            executable: executable,
-            arguments: arguments,
-            workingDirectory: workingDirectory,
-            analytics: analytics,
-            logLevelRegex: logLevelRegex,
-            onStdErrMessage: onStdErrMessage,
-            successExitCodes: successExitCodes);
+      this.expectReadyMessageOnce = true});
 
   Completer? _readyCompleter;
   final _readyStopwatch = Stopwatch();
@@ -281,24 +272,15 @@ class ProcessParentReadyTask extends ProcessReadyTask {
   StreamSubscription? _childTaskMessagesSubscription;
 
   ProcessParentReadyTask(
-      {required String taskName,
-      required String executable,
-      required List<String> arguments,
-      required String workingDirectory,
-      required Analytics analytics,
-      List<int>? successExitCodes,
-      required String readyMessage,
-      bool expectReadyMessageOnce = true,
-      required this.childTaskMessages})
-      : super(
-            taskName: taskName,
-            executable: executable,
-            arguments: arguments,
-            workingDirectory: workingDirectory,
-            analytics: analytics,
-            readyMessage: readyMessage,
-            expectReadyMessageOnce: expectReadyMessageOnce,
-            successExitCodes: successExitCodes);
+      {required super.taskName,
+      required super.executable,
+      required super.arguments,
+      required super.workingDirectory,
+      required super.analytics,
+      super.successExitCodes,
+      required super.readyMessage,
+      super.expectReadyMessageOnce,
+      required this.childTaskMessages});
 
   @override
   Future run() async {

--- a/cli/lib/src/task_runner/reload_crash.dart
+++ b/cli/lib/src/task_runner/reload_crash.dart
@@ -1,6 +1,6 @@
-/// Tracks hot reload crash documented here:
-/// - https://github.com/flutter/flutter/issues/120841
-/// - https://github.com/Dropsource/monarch/issues/72
+// Tracks hot reload crash documented here:
+// - https://github.com/flutter/flutter/issues/120841
+// - https://github.com/Dropsource/monarch/issues/72
 
 import '../version_api/notification.dart';
 

--- a/cli/lib/src/task_runner/task_runner.dart
+++ b/cli/lib/src/task_runner/task_runner.dart
@@ -357,7 +357,6 @@ class TaskRunner extends LongRunningCli<CliExitCode> with Log {
           defaultLogLevel.name, // log-level
           discoveryServerPort.toString(), // discovery-server-port
           config.pubspecProjectName, // project-name
-          config.projectDirectory.path, // project-directory-path
         ],
         workingDirectory: projectDirectory.path,
         analytics: analytics,

--- a/cli/lib/src/task_runner/task_runner.dart
+++ b/cli/lib/src/task_runner/task_runner.dart
@@ -578,8 +578,6 @@ $monarchIsReady. Project changes will reload automatically with hot restart.''')
         stdout_default.writeln('''
 $monarchIsReady. Press "r" or "R" to reload project changes.''');
         break;
-
-      default:
     }
   }
 }

--- a/cli/lib/src/task_runner/task_runner.dart
+++ b/cli/lib/src/task_runner/task_runner.dart
@@ -317,6 +317,7 @@ class TaskRunner extends LongRunningCli<CliExitCode> with Log {
           defaultLogLevel.name, // log-level
           discoveryServerPort.toString(), // discovery-server-port
           config.pubspecProjectName, // project-name
+          config.projectDirectory.path, // project-directory-path
         ],
         workingDirectory: projectDirectory.path,
         analytics: analytics,
@@ -336,6 +337,7 @@ class TaskRunner extends LongRunningCli<CliExitCode> with Log {
           p.join(projectDirectory.path, dotMonarch), // preview-window-bundle
           defaultLogLevel.name, // log-level
           discoveryServerPort.toString(), // discovery-server-port
+          config.projectDirectory.path, // project-directory-path
         ],
         workingDirectory: projectDirectory.path,
         analytics: analytics,
@@ -355,6 +357,7 @@ class TaskRunner extends LongRunningCli<CliExitCode> with Log {
           defaultLogLevel.name, // log-level
           discoveryServerPort.toString(), // discovery-server-port
           config.pubspecProjectName, // project-name
+          config.projectDirectory.path, // project-directory-path
         ],
         workingDirectory: projectDirectory.path,
         analytics: analytics,

--- a/cli/lib/src/task_runner/tasks_managers.dart
+++ b/cli/lib/src/task_runner/tasks_managers.dart
@@ -40,7 +40,6 @@ abstract class TasksManager with Log {
           }
           break;
 
-        default:
       }
     });
   }

--- a/cli/lib/src/utils/managed_process.dart
+++ b/cli/lib/src/utils/managed_process.dart
@@ -116,15 +116,10 @@ class ManagedProcess {
 /// stdout and stderr streams after the process starts.
 abstract class ThrowsManagedProcess extends ManagedProcess {
   ThrowsManagedProcess(
-      {required String loggerName,
-      required String executable,
-      required List<String> arguments,
-      String? workingDirectory})
-      : super(
-            loggerName: loggerName,
-            executable: executable,
-            arguments: arguments,
-            workingDirectory: workingDirectory);
+      {required super.loggerName,
+      required super.executable,
+      required super.arguments,
+      super.workingDirectory});
 
   @override
   Future<void> start() async {

--- a/cli/pubspec.yaml
+++ b/cli/pubspec.yaml
@@ -1,15 +1,15 @@
 name: monarch_cli
 description: Command-line interface for Monarch binaries.
-version: 3.0.5
+version: 3.1.0
 publish_to: none
 
 environment:
-  sdk: '>=2.16.1 <3.0.0'
+  sdk: ^3.2.0
 
 dependencies:
   pubspec_parse: ^1.0.0
   checked_yaml: ^2.0.1
-  uuid: ^3.0.4
+  uuid: ^4.5.1
   pub_semver: ^2.0.0
   args: ^2.1.0
   yaml_edit: ^2.0.0
@@ -18,15 +18,15 @@ dependencies:
   meta: ^1.8.0
   io: ^1.0.3
   yaml: ^3.1.1
-  grpc: ^3.1.0
-  http: ^0.13.5
-  monarch_utils: ^1.0.4
-  monarch_http: ^1.2.0
-  monarch_io_utils: ^1.3.0
-  monarch_grpc: ^2.3.1
+  grpc: ^4.0.1
+  http: ^1.3.0
+  monarch_utils: ^1.2.0
+  monarch_http: ^1.3.0
+  monarch_io_utils: ^1.4.0
+  monarch_grpc: ^2.4.0
 
 dev_dependencies:
-  lints: ^2.0.1
+  lints: ^5.1.1
   test: ^1.17.2
   mockito: ^5.0.7
   build_runner:

--- a/cli/test/analytics_event_queue_test.dart
+++ b/cli/test/analytics_event_queue_test.dart
@@ -206,7 +206,7 @@ void main() {
 const testRetryDuration = Duration(milliseconds: 100);
 
 class TestAnalyticsEventsQueue extends AnalyticsEventsQueue {
-  TestAnalyticsEventsQueue(AbstractAnalyticsApi api) : super(api);
+  TestAnalyticsEventsQueue(super.api);
   @override
   Duration get timeBetweenRetries => testRetryDuration;
 }

--- a/cli/test/devtools_discovery_macos_test.dart
+++ b/cli/test/devtools_discovery_macos_test.dart
@@ -1,4 +1,5 @@
 @TestOn('mac-os')
+library;
 
 import 'package:monarch_cli/src/task_runner/devtools_discovery.dart.dart';
 import 'package:test/test.dart';

--- a/cli/test/devtools_discovery_windows_test.dart
+++ b/cli/test/devtools_discovery_windows_test.dart
@@ -1,4 +1,5 @@
 @TestOn('windows')
+library;
 
 import 'package:monarch_cli/src/task_runner/devtools_discovery.dart.dart';
 import 'package:test/test.dart';

--- a/cli/test/monarch_app_stderr_macos_test.dart
+++ b/cli/test/monarch_app_stderr_macos_test.dart
@@ -1,4 +1,5 @@
 @TestOn('mac-os')
+library;
 
 import 'package:test/test.dart';
 import 'package:monarch_utils/log.dart';

--- a/cli/test/monarch_app_stderr_windows_test.dart
+++ b/cli/test/monarch_app_stderr_windows_test.dart
@@ -1,4 +1,5 @@
 @TestOn('windows')
+library;
 
 import 'package:test/test.dart';
 import 'package:monarch_utils/log.dart';

--- a/cli/test/monarch_ui_fetcher_test.dart
+++ b/cli/test/monarch_ui_fetcher_test.dart
@@ -580,17 +580,11 @@ class TestFetcher extends MonarchUiFetcher {
   bool zipFileDeleted = false;
 
   TestFetcher(
-      {required StandardOutput stdout_,
-      required MonarchBinaries monarchBinaries,
-      required String binariesVersionNumber,
-      required FlutterSdkId id,
-      required String userDeviceId})
-      : super(
-            stdout_: stdout_,
-            monarchBinaries: monarchBinaries,
-            binariesVersionNumber: binariesVersionNumber,
-            id: id,
-            userDeviceId: userDeviceId);
+      {required super.stdout_,
+      required super.monarchBinaries,
+      required super.binariesVersionNumber,
+      required super.id,
+      required super.userDeviceId});
 
   @override
   VersionApi getVersionApi(String userDeviceId) => mockVersionApi;

--- a/cli/test/upgrade_validator_macos_test.dart
+++ b/cli/test/upgrade_validator_macos_test.dart
@@ -1,4 +1,5 @@
 @TestOn('mac-os')
+library;
 
 import 'package:test/test.dart';
 import 'package:monarch_cli/src/upgrade/upgrade_validator.dart';

--- a/cli/test/upgrade_validator_windows_test.dart
+++ b/cli/test/upgrade_validator_windows_test.dart
@@ -1,4 +1,5 @@
 @TestOn('windows')
+library;
 
 import 'package:test/test.dart';
 import 'package:monarch_cli/src/upgrade/upgrade_validator.dart';

--- a/controller/CHANGELOG.md
+++ b/controller/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 1.5.0 - 2025-03-10
+## 1.5.1 - 2025-03-10
 - Upgrades dependencies and sdk
 - Fixes lints
+- Puts back dock dropdown
 
 ## 1.4.2 - 2024-01-17
 - Use latest version of stockholm via fork

--- a/controller/CHANGELOG.md
+++ b/controller/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.0 - 2025-03-10
+- Upgrades dependencies and sdk
+- Fixes lints
+
 ## 1.4.2 - 2024-01-17
 - Use latest version of stockholm via fork
 

--- a/controller/lib/main.dart
+++ b/controller/lib/main.dart
@@ -77,7 +77,7 @@ void setUpChannels(int discoveryServerPort) async {
 }
 
 class MonarchControllerApp extends StatelessWidget {
-  const MonarchControllerApp({Key? key}) : super(key: key);
+  const MonarchControllerApp({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/controller/lib/screens/controller_screen.dart
+++ b/controller/lib/screens/controller_screen.dart
@@ -9,9 +9,9 @@ import '../widgets/control_panel/control_panel.dart';
 
 class ControllerScreen extends StatefulWidget {
   const ControllerScreen({
-    Key? key,
+    super.key,
     required this.manager,
-  }) : super(key: key);
+  });
 
   final ControllerManager manager;
 

--- a/controller/lib/widgets/components/button.dart
+++ b/controller/lib/widgets/components/button.dart
@@ -13,7 +13,7 @@ class StockholmButton extends StatelessWidget {
   final FocusNode? focusNode;
 
   const StockholmButton({
-    Key? key,
+    super.key,
     required this.onPressed,
     required this.child,
     this.padding = const EdgeInsets.symmetric(
@@ -23,7 +23,7 @@ class StockholmButton extends StatelessWidget {
     this.important = false,
     this.enabled = true,
     this.focusNode,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/controller/lib/widgets/components/checkbox_list.dart
+++ b/controller/lib/widgets/components/checkbox_list.dart
@@ -9,10 +9,10 @@ class CheckboxList extends StatelessWidget {
   final Function(String, bool)? onFlagToggled;
 
   const CheckboxList({
-    Key? key,
+    super.key,
     required this.visualDebugFlags,
     this.onFlagToggled,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/controller/lib/widgets/components/dropdown.dart
+++ b/controller/lib/widgets/components/dropdown.dart
@@ -26,7 +26,7 @@ class DropDown<T> extends StatelessWidget {
     required this.toStringFunction,
     this.horizontalPadding = 16,
     this.skipTraversal = false,
-  })  : stringfiedValues = {for (var e in values) toStringFunction(e): e};
+  }) : stringfiedValues = {for (var e in values) toStringFunction(e): e};
 
   @override
   Widget build(BuildContext context) => StockholmDropdownButton<String>(

--- a/controller/lib/widgets/components/dropdown.dart
+++ b/controller/lib/widgets/components/dropdown.dart
@@ -19,15 +19,14 @@ class DropDown<T> extends StatelessWidget {
   T get(String val) => stringfiedValues[val]!;
 
   DropDown({
-    Key? key,
+    super.key,
     required this.currentValue,
     required this.values,
     this.onChange,
     required this.toStringFunction,
     this.horizontalPadding = 16,
     this.skipTraversal = false,
-  })  : stringfiedValues = {for (var e in values) toStringFunction(e): e},
-        super(key: key);
+  })  : stringfiedValues = {for (var e in values) toStringFunction(e): e};
 
   @override
   Widget build(BuildContext context) => StockholmDropdownButton<String>(

--- a/controller/lib/widgets/components/dropdown_button.dart
+++ b/controller/lib/widgets/components/dropdown_button.dart
@@ -18,8 +18,8 @@ class StockholmDropdownButton<T> extends StatefulWidget {
     ),
     this.width,
     this.skipTraversal = false,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   final List<StockholmDropdownItem<T>> items;
   final ValueChanged<T> onChanged;
@@ -122,8 +122,8 @@ class StockholmDropdownItem<T> extends StatelessWidget {
   const StockholmDropdownItem({
     required this.value,
     required this.child,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   final T value;
   final Widget child;

--- a/controller/lib/widgets/components/labeled_control.dart
+++ b/controller/lib/widgets/components/labeled_control.dart
@@ -11,7 +11,7 @@ class LabeledControl extends Padding {
   final bool shouldTranslate;
 
   LabeledControl({
-    Key? key,
+    super.key,
     required this.label,
     required this.control,
     this.controlWidth = 340,
@@ -20,7 +20,6 @@ class LabeledControl extends Padding {
     this.horizontalPadding = 0,
     this.shouldTranslate = true,
   }) : super(
-          key: key,
           padding: EdgeInsets.symmetric(
               vertical: verticalPadding, horizontal: horizontalPadding),
           child: Row(

--- a/controller/lib/widgets/components/menu_items.dart
+++ b/controller/lib/widgets/components/menu_items.dart
@@ -6,8 +6,7 @@ const _menuPadding = 4.0;
 /// StockholmMenu with a ListView child instead of an IntrinsicWidth child.
 class ScrollableStockholmMenu extends StockholmMenu {
   const ScrollableStockholmMenu(
-      {required List<StockholmMenuEntity> items, double? width, Key? key})
-      : super(items: items, width: width, key: key);
+      {required super.items, super.width, super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/controller/lib/widgets/components/menu_items.dart
+++ b/controller/lib/widgets/components/menu_items.dart
@@ -5,8 +5,7 @@ const _menuPadding = 4.0;
 
 /// StockholmMenu with a ListView child instead of an IntrinsicWidth child.
 class ScrollableStockholmMenu extends StockholmMenu {
-  const ScrollableStockholmMenu(
-      {required super.items, super.width, super.key});
+  const ScrollableStockholmMenu({required super.items, super.width, super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/controller/lib/widgets/components/no_stories_found_text.dart
+++ b/controller/lib/widgets/components/no_stories_found_text.dart
@@ -2,9 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:monarch_controller/widgets/components/text.dart';
 
 class NoStoriesFoundWidget extends Center {
-  const NoStoriesFoundWidget({Key? key})
+  const NoStoriesFoundWidget({super.key})
       : super(
-            key: key,
             child: const Padding(
               padding: EdgeInsets.only(top: 8.0),
               child: TextBody1(

--- a/controller/lib/widgets/components/no_stories_found_text.dart
+++ b/controller/lib/widgets/components/no_stories_found_text.dart
@@ -5,10 +5,10 @@ class NoStoriesFoundWidget extends Center {
   const NoStoriesFoundWidget({super.key})
       : super(
             child: const Padding(
-              padding: EdgeInsets.only(top: 8.0),
-              child: TextBody1(
-                'story_list.no_stories',
-                shouldTranslate: true,
-              ),
-            ));
+          padding: EdgeInsets.only(top: 8.0),
+          child: TextBody1(
+            'story_list.no_stories',
+            shouldTranslate: true,
+          ),
+        ));
 }

--- a/controller/lib/widgets/components/numbered_slider.dart
+++ b/controller/lib/widgets/components/numbered_slider.dart
@@ -11,10 +11,10 @@ class NumberedSlider extends StatefulWidget {
   final Function(double) onChanged;
 
   const NumberedSlider({
-    Key? key,
+    super.key,
     this.initialValue = 1.0,
     required this.onChanged,
-  }) : super(key: key);
+  });
 
   @override
   State<NumberedSlider> createState() => _NumberedSlideState();

--- a/controller/lib/widgets/components/text.dart
+++ b/controller/lib/widgets/components/text.dart
@@ -5,38 +5,22 @@ import '../../../utils/translations.dart';
 
 class TextHeadline1 extends TextWidget {
   const TextHeadline1(
-    String text, {
-    Key? key,
-    List<String>? args,
-    bool? shouldTranslate,
-    bool? shouldBeCopyable,
-    String? copyConfirmationText,
-    TextAlign? textAlign,
-    TextOverflow? overflow,
-    int? maxLines,
-    double? maxFontSize,
-    double? minFontSize,
-    bool? shouldAutoResize,
-    bool? shouldUpperCase,
-    double? fontSizeMultiplier,
-    TextStyle? styles,
-  }) : super(
-          text,
-          key: key,
-          shouldTranslate: shouldTranslate,
-          shouldBeCopyable: shouldBeCopyable,
-          copyConfirmationText: copyConfirmationText,
-          styles: styles,
-          args: args,
-          textAlign: textAlign,
-          overflow: overflow,
-          maxLines: maxLines,
-          maxFontSize: maxFontSize,
-          minFontSize: minFontSize,
-          shouldAutoResize: shouldAutoResize,
-          fontSizeMultiplier: fontSizeMultiplier,
-          shouldUpperCase: shouldUpperCase,
-        );
+    super.text, {
+    super.key,
+    super.args,
+    super.shouldTranslate,
+    super.shouldBeCopyable,
+    super.copyConfirmationText,
+    super.textAlign = null,
+    super.overflow,
+    super.maxLines,
+    super.maxFontSize,
+    super.minFontSize,
+    super.shouldAutoResize,
+    super.shouldUpperCase,
+    super.fontSizeMultiplier,
+    super.styles,
+  });
 
   @override
   TextStyle? style(BuildContext context) =>
@@ -45,38 +29,22 @@ class TextHeadline1 extends TextWidget {
 
 class TextHeadline2 extends TextWidget {
   const TextHeadline2(
-    String text, {
-    Key? key,
-    List<String>? args,
-    bool? shouldTranslate,
-    bool? shouldBeCopyable,
-    String? copyConfirmationText,
-    TextAlign? textAlign,
-    TextOverflow? overflow,
-    int? maxLines,
-    double? maxFontSize,
-    double? minFontSize,
-    bool? shouldAutoResize,
-    bool? shouldUpperCase,
-    double? fontSizeMultiplier,
-    TextStyle? styles,
-  }) : super(
-          text,
-          key: key,
-          shouldTranslate: shouldTranslate,
-          shouldBeCopyable: shouldBeCopyable,
-          copyConfirmationText: copyConfirmationText,
-          styles: styles,
-          args: args,
-          textAlign: textAlign,
-          overflow: overflow,
-          maxLines: maxLines,
-          maxFontSize: maxFontSize,
-          minFontSize: minFontSize,
-          shouldAutoResize: shouldAutoResize,
-          fontSizeMultiplier: fontSizeMultiplier,
-          shouldUpperCase: shouldUpperCase,
-        );
+    super.text, {
+    super.key,
+    super.args,
+    super.shouldTranslate,
+    super.shouldBeCopyable,
+    super.copyConfirmationText,
+    super.textAlign = null,
+    super.overflow,
+    super.maxLines,
+    super.maxFontSize,
+    super.minFontSize,
+    super.shouldAutoResize,
+    super.shouldUpperCase,
+    super.fontSizeMultiplier,
+    super.styles,
+  });
 
   @override
   TextStyle? style(BuildContext context) =>
@@ -85,38 +53,22 @@ class TextHeadline2 extends TextWidget {
 
 class TextHeadline3 extends TextWidget {
   const TextHeadline3(
-    String text, {
-    Key? key,
-    List<String>? args,
-    bool? shouldTranslate,
-    bool? shouldBeCopyable,
-    String? copyConfirmationText,
-    TextAlign? textAlign,
-    TextOverflow? overflow,
-    int? maxLines,
-    double? maxFontSize,
-    double? minFontSize,
-    bool? shouldAutoResize,
-    bool? shouldUpperCase,
-    double? fontSizeMultiplier,
-    TextStyle? styles,
-  }) : super(
-          text,
-          key: key,
-          shouldTranslate: shouldTranslate,
-          shouldBeCopyable: shouldBeCopyable,
-          copyConfirmationText: copyConfirmationText,
-          styles: styles,
-          args: args,
-          textAlign: textAlign,
-          overflow: overflow,
-          maxLines: maxLines,
-          maxFontSize: maxFontSize,
-          minFontSize: minFontSize,
-          shouldAutoResize: shouldAutoResize,
-          fontSizeMultiplier: fontSizeMultiplier,
-          shouldUpperCase: shouldUpperCase,
-        );
+    super.text, {
+    super.key,
+    super.args,
+    super.shouldTranslate,
+    super.shouldBeCopyable,
+    super.copyConfirmationText,
+    super.textAlign = null,
+    super.overflow,
+    super.maxLines,
+    super.maxFontSize,
+    super.minFontSize,
+    super.shouldAutoResize,
+    super.shouldUpperCase,
+    super.fontSizeMultiplier,
+    super.styles,
+  });
 
   @override
   TextStyle? style(BuildContext context) =>
@@ -125,38 +77,22 @@ class TextHeadline3 extends TextWidget {
 
 class TextHeadline4 extends TextWidget {
   const TextHeadline4(
-    String text, {
-    Key? key,
-    List<String>? args,
-    bool? shouldTranslate,
-    bool? shouldBeCopyable,
-    String? copyConfirmationText,
-    TextAlign? textAlign,
-    TextOverflow? overflow,
-    int? maxLines,
-    double? maxFontSize,
-    double? minFontSize,
-    bool? shouldAutoResize,
-    bool? shouldUpperCase,
-    double? fontSizeMultiplier,
-    TextStyle? styles,
-  }) : super(
-          text,
-          key: key,
-          shouldTranslate: shouldTranslate,
-          shouldBeCopyable: shouldBeCopyable,
-          copyConfirmationText: copyConfirmationText,
-          styles: styles,
-          args: args,
-          textAlign: textAlign,
-          overflow: overflow,
-          maxLines: maxLines,
-          maxFontSize: maxFontSize,
-          minFontSize: minFontSize,
-          shouldAutoResize: shouldAutoResize,
-          fontSizeMultiplier: fontSizeMultiplier,
-          shouldUpperCase: shouldUpperCase,
-        );
+    super.text, {
+    super.key,
+    super.args,
+    super.shouldTranslate,
+    super.shouldBeCopyable,
+    super.copyConfirmationText,
+    super.textAlign = null,
+    super.overflow,
+    super.maxLines,
+    super.maxFontSize,
+    super.minFontSize,
+    super.shouldAutoResize,
+    super.shouldUpperCase,
+    super.fontSizeMultiplier,
+    super.styles,
+  });
 
   @override
   TextStyle? style(BuildContext context) =>
@@ -165,38 +101,22 @@ class TextHeadline4 extends TextWidget {
 
 class TextHeadline5 extends TextWidget {
   const TextHeadline5(
-    String text, {
-    Key? key,
-    List<String>? args,
-    bool? shouldTranslate,
-    bool? shouldBeCopyable,
-    String? copyConfirmationText,
-    TextAlign? textAlign,
-    TextOverflow? overflow,
-    int? maxLines,
-    double? maxFontSize,
-    double? minFontSize,
-    bool? shouldAutoResize,
-    bool? shouldUpperCase,
-    double? fontSizeMultiplier,
-    TextStyle? styles,
-  }) : super(
-          text,
-          key: key,
-          shouldTranslate: shouldTranslate,
-          shouldBeCopyable: shouldBeCopyable,
-          copyConfirmationText: copyConfirmationText,
-          styles: styles,
-          args: args,
-          textAlign: textAlign,
-          overflow: overflow,
-          maxLines: maxLines,
-          maxFontSize: maxFontSize,
-          minFontSize: minFontSize,
-          shouldAutoResize: shouldAutoResize,
-          fontSizeMultiplier: fontSizeMultiplier,
-          shouldUpperCase: shouldUpperCase,
-        );
+    super.text, {
+    super.key,
+    super.args,
+    super.shouldTranslate,
+    super.shouldBeCopyable,
+    super.copyConfirmationText,
+    super.textAlign = null,
+    super.overflow,
+    super.maxLines,
+    super.maxFontSize,
+    super.minFontSize,
+    super.shouldAutoResize,
+    super.shouldUpperCase,
+    super.fontSizeMultiplier,
+    super.styles,
+  });
 
   @override
   TextStyle? style(BuildContext context) =>
@@ -205,38 +125,22 @@ class TextHeadline5 extends TextWidget {
 
 class TextHeadline6 extends TextWidget {
   const TextHeadline6(
-    String text, {
-    Key? key,
-    List<String>? args,
-    bool? shouldTranslate,
-    bool? shouldBeCopyable,
-    String? copyConfirmationText,
-    TextAlign? textAlign,
-    TextOverflow? overflow,
-    int? maxLines,
-    double? maxFontSize,
-    double? minFontSize,
-    bool? shouldAutoResize,
-    bool? shouldUpperCase,
-    double? fontSizeMultiplier,
-    TextStyle? styles,
-  }) : super(
-          text,
-          key: key,
-          shouldTranslate: shouldTranslate,
-          shouldBeCopyable: shouldBeCopyable,
-          copyConfirmationText: copyConfirmationText,
-          styles: styles,
-          args: args,
-          textAlign: textAlign,
-          overflow: overflow,
-          maxLines: maxLines,
-          maxFontSize: maxFontSize,
-          minFontSize: minFontSize,
-          shouldAutoResize: shouldAutoResize,
-          fontSizeMultiplier: fontSizeMultiplier,
-          shouldUpperCase: shouldUpperCase,
-        );
+    super.text, {
+    super.key,
+    super.args,
+    super.shouldTranslate,
+    super.shouldBeCopyable,
+    super.copyConfirmationText,
+    super.textAlign = null,
+    super.overflow,
+    super.maxLines,
+    super.maxFontSize,
+    super.minFontSize,
+    super.shouldAutoResize,
+    super.shouldUpperCase,
+    super.fontSizeMultiplier,
+    super.styles,
+  });
 
   @override
   TextStyle? style(BuildContext context) =>
@@ -245,38 +149,22 @@ class TextHeadline6 extends TextWidget {
 
 class TextSubtitle1 extends TextWidget {
   const TextSubtitle1(
-    String text, {
-    Key? key,
-    List<String>? args,
-    bool? shouldTranslate,
-    bool? shouldBeCopyable,
-    String? copyConfirmationText,
-    TextAlign? textAlign,
-    TextOverflow? overflow,
-    int? maxLines,
-    double? maxFontSize,
-    double? minFontSize,
-    bool? shouldAutoResize,
-    bool? shouldUpperCase,
-    double? fontSizeMultiplier,
-    TextStyle? styles,
-  }) : super(
-          text,
-          key: key,
-          shouldTranslate: shouldTranslate,
-          shouldBeCopyable: shouldBeCopyable,
-          copyConfirmationText: copyConfirmationText,
-          styles: styles,
-          args: args,
-          textAlign: textAlign,
-          overflow: overflow,
-          maxLines: maxLines,
-          maxFontSize: maxFontSize,
-          minFontSize: minFontSize,
-          shouldAutoResize: shouldAutoResize,
-          fontSizeMultiplier: fontSizeMultiplier,
-          shouldUpperCase: shouldUpperCase,
-        );
+    super.text, {
+    super.key,
+    super.args,
+    super.shouldTranslate,
+    super.shouldBeCopyable,
+    super.copyConfirmationText,
+    super.textAlign = null,
+    super.overflow,
+    super.maxLines,
+    super.maxFontSize,
+    super.minFontSize,
+    super.shouldAutoResize,
+    super.shouldUpperCase,
+    super.fontSizeMultiplier,
+    super.styles,
+  });
 
   @override
   TextStyle? style(BuildContext context) =>
@@ -285,38 +173,22 @@ class TextSubtitle1 extends TextWidget {
 
 class TextSubtitle2 extends TextWidget {
   const TextSubtitle2(
-    String text, {
-    Key? key,
-    List<String>? args,
-    bool? shouldTranslate,
-    bool? shouldBeCopyable,
-    String? copyConfirmationText,
-    TextAlign? textAlign,
-    TextOverflow? overflow,
-    int? maxLines,
-    double? maxFontSize,
-    double? minFontSize,
-    bool? shouldAutoResize,
-    bool? shouldUpperCase,
-    double? fontSizeMultiplier,
-    TextStyle? styles,
-  }) : super(
-          text,
-          key: key,
-          shouldTranslate: shouldTranslate,
-          shouldBeCopyable: shouldBeCopyable,
-          copyConfirmationText: copyConfirmationText,
-          styles: styles,
-          args: args,
-          textAlign: textAlign,
-          overflow: overflow,
-          maxLines: maxLines,
-          maxFontSize: maxFontSize,
-          minFontSize: minFontSize,
-          shouldAutoResize: shouldAutoResize,
-          fontSizeMultiplier: fontSizeMultiplier,
-          shouldUpperCase: shouldUpperCase,
-        );
+    super.text, {
+    super.key,
+    super.args,
+    super.shouldTranslate,
+    super.shouldBeCopyable,
+    super.copyConfirmationText,
+    super.textAlign = null,
+    super.overflow,
+    super.maxLines,
+    super.maxFontSize,
+    super.minFontSize,
+    super.shouldAutoResize,
+    super.shouldUpperCase,
+    super.fontSizeMultiplier,
+    super.styles,
+  });
 
   @override
   TextStyle? style(BuildContext context) =>
@@ -325,38 +197,22 @@ class TextSubtitle2 extends TextWidget {
 
 class TextBody1 extends TextWidget {
   const TextBody1(
-    String text, {
-    Key? key,
-    List<String>? args,
-    bool? shouldTranslate,
-    bool? shouldBeCopyable,
-    String? copyConfirmationText,
-    TextAlign? textAlign,
-    TextOverflow? overflow,
-    int? maxLines,
-    double? maxFontSize,
-    double? minFontSize,
-    bool? shouldAutoResize,
-    bool? shouldUpperCase,
-    double? fontSizeMultiplier,
-    TextStyle? styles,
-  }) : super(
-          text,
-          key: key,
-          shouldTranslate: shouldTranslate,
-          shouldBeCopyable: shouldBeCopyable,
-          copyConfirmationText: copyConfirmationText,
-          styles: styles,
-          args: args,
-          textAlign: textAlign,
-          overflow: overflow,
-          maxLines: maxLines,
-          maxFontSize: maxFontSize,
-          minFontSize: minFontSize,
-          shouldAutoResize: shouldAutoResize,
-          fontSizeMultiplier: fontSizeMultiplier,
-          shouldUpperCase: shouldUpperCase,
-        );
+    super.text, {
+    super.key,
+    super.args,
+    super.shouldTranslate,
+    super.shouldBeCopyable,
+    super.copyConfirmationText,
+    super.textAlign = null,
+    super.overflow,
+    super.maxLines,
+    super.maxFontSize,
+    super.minFontSize,
+    super.shouldAutoResize,
+    super.shouldUpperCase,
+    super.fontSizeMultiplier,
+    super.styles,
+  });
 
   @override
   TextStyle? style(BuildContext context) =>
@@ -365,38 +221,22 @@ class TextBody1 extends TextWidget {
 
 class TextBody2 extends TextWidget {
   const TextBody2(
-    String text, {
-    Key? key,
-    List<String>? args,
-    bool? shouldTranslate,
-    bool? shouldBeCopyable,
-    String? copyConfirmationText,
-    TextAlign? textAlign,
-    TextOverflow? overflow,
-    int? maxLines,
-    double? maxFontSize,
-    double? minFontSize,
-    bool? shouldAutoResize,
-    bool? shouldUpperCase,
-    double? fontSizeMultiplier,
-    TextStyle? styles,
-  }) : super(
-          text,
-          key: key,
-          shouldTranslate: shouldTranslate,
-          shouldBeCopyable: shouldBeCopyable,
-          copyConfirmationText: copyConfirmationText,
-          styles: styles,
-          args: args,
-          textAlign: textAlign,
-          overflow: overflow,
-          maxLines: maxLines,
-          maxFontSize: maxFontSize,
-          minFontSize: minFontSize,
-          shouldAutoResize: shouldAutoResize,
-          fontSizeMultiplier: fontSizeMultiplier,
-          shouldUpperCase: shouldUpperCase,
-        );
+    super.text, {
+    super.key,
+    super.args,
+    super.shouldTranslate,
+    super.shouldBeCopyable,
+    super.copyConfirmationText,
+    super.textAlign = null,
+    super.overflow,
+    super.maxLines,
+    super.maxFontSize,
+    super.minFontSize,
+    super.shouldAutoResize,
+    super.shouldUpperCase,
+    super.fontSizeMultiplier,
+    super.styles,
+  });
 
   @override
   TextStyle? style(BuildContext context) =>
@@ -405,38 +245,22 @@ class TextBody2 extends TextWidget {
 
 class TextCaption extends TextWidget {
   const TextCaption(
-    String text, {
-    Key? key,
-    List<String>? args,
-    bool? shouldTranslate,
-    bool? shouldBeCopyable,
-    String? copyConfirmationText,
-    TextAlign? textAlign,
-    TextOverflow? overflow,
-    int? maxLines,
-    double? maxFontSize,
-    double? minFontSize,
-    bool? shouldAutoResize,
-    bool? shouldUpperCase,
-    double? fontSizeMultiplier,
-    TextStyle? styles,
-  }) : super(
-          text,
-          key: key,
-          shouldTranslate: shouldTranslate,
-          shouldBeCopyable: shouldBeCopyable,
-          copyConfirmationText: copyConfirmationText,
-          styles: styles,
-          args: args,
-          textAlign: textAlign,
-          overflow: overflow,
-          maxLines: maxLines,
-          maxFontSize: maxFontSize,
-          minFontSize: minFontSize,
-          shouldAutoResize: shouldAutoResize,
-          fontSizeMultiplier: fontSizeMultiplier,
-          shouldUpperCase: shouldUpperCase,
-        );
+    super.text, {
+    super.key,
+    super.args,
+    super.shouldTranslate,
+    super.shouldBeCopyable,
+    super.copyConfirmationText,
+    super.textAlign = null,
+    super.overflow,
+    super.maxLines,
+    super.maxFontSize,
+    super.minFontSize,
+    super.shouldAutoResize,
+    super.shouldUpperCase,
+    super.fontSizeMultiplier,
+    super.styles,
+  });
 
   @override
   TextStyle? style(BuildContext context) =>
@@ -445,38 +269,22 @@ class TextCaption extends TextWidget {
 
 class TextOverline extends TextWidget {
   const TextOverline(
-    String text, {
-    Key? key,
-    List<String>? args,
-    bool? shouldTranslate,
-    bool? shouldBeCopyable,
-    String? copyConfirmationText,
-    TextAlign? textAlign,
-    TextOverflow? overflow,
-    int? maxLines,
-    double? maxFontSize,
-    double? minFontSize,
-    bool? shouldAutoResize,
-    bool? shouldUpperCase,
-    double? fontSizeMultiplier,
-    TextStyle? styles,
-  }) : super(
-          text,
-          key: key,
-          shouldTranslate: shouldTranslate,
-          shouldBeCopyable: shouldBeCopyable,
-          copyConfirmationText: copyConfirmationText,
-          styles: styles,
-          args: args,
-          textAlign: textAlign,
-          overflow: overflow,
-          maxLines: maxLines,
-          maxFontSize: maxFontSize,
-          minFontSize: minFontSize,
-          shouldAutoResize: shouldAutoResize,
-          fontSizeMultiplier: fontSizeMultiplier,
-          shouldUpperCase: shouldUpperCase,
-        );
+    super.text, {
+    super.key,
+    super.args,
+    super.shouldTranslate,
+    super.shouldBeCopyable,
+    super.copyConfirmationText,
+    super.textAlign = null,
+    super.overflow,
+    super.maxLines,
+    super.maxFontSize,
+    super.minFontSize,
+    super.shouldAutoResize,
+    super.shouldUpperCase,
+    super.fontSizeMultiplier,
+    super.styles,
+  });
 
   @override
   TextStyle? style(BuildContext context) =>
@@ -485,38 +293,22 @@ class TextOverline extends TextWidget {
 
 class ButtonText extends TextWidget {
   const ButtonText(
-    String text, {
-    Key? key,
-    List<String>? args,
-    bool? shouldTranslate,
-    bool? shouldBeCopyable,
-    String? copyConfirmationText,
-    TextAlign? textAlign,
-    TextOverflow? overflow,
-    int? maxLines,
-    double? maxFontSize,
-    double? minFontSize,
-    bool? shouldAutoResize,
-    bool? shouldUpperCase,
-    double? fontSizeMultiplier,
-    TextStyle? styles,
-  }) : super(
-          text,
-          key: key,
-          shouldTranslate: shouldTranslate,
-          shouldBeCopyable: shouldBeCopyable,
-          copyConfirmationText: copyConfirmationText,
-          styles: styles,
-          args: args,
-          textAlign: textAlign,
-          overflow: overflow,
-          maxLines: maxLines,
-          maxFontSize: maxFontSize,
-          minFontSize: minFontSize,
-          shouldAutoResize: shouldAutoResize,
-          fontSizeMultiplier: fontSizeMultiplier,
-          shouldUpperCase: shouldUpperCase,
-        );
+    super.text, {
+    super.key,
+    super.args,
+    super.shouldTranslate,
+    super.shouldBeCopyable,
+    super.copyConfirmationText,
+    super.textAlign = null,
+    super.overflow,
+    super.maxLines,
+    super.maxFontSize,
+    super.minFontSize,
+    super.shouldAutoResize,
+    super.shouldUpperCase,
+    super.fontSizeMultiplier,
+    super.styles,
+  });
 
   @override
   TextStyle? style(BuildContext context) =>
@@ -555,8 +347,8 @@ abstract class TextWidget extends StatelessWidget {
     this.args,
     this.textAlign = TextAlign.start,
     this.shouldUpperCase,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   bool get _shouldTranslate => shouldTranslate ?? false;
 

--- a/controller/lib/widgets/control_panel/control_panel.dart
+++ b/controller/lib/widgets/control_panel/control_panel.dart
@@ -97,7 +97,6 @@ class ControlPanel extends StatelessWidget {
             controlWidth: controlWidth,
           ),
           const ControlPanelDivider(),
-
           LabeledControl(
             label: 'controls.scale',
             control: DropDown<StoryScaleDefinition>(
@@ -125,7 +124,6 @@ class ControlPanel extends StatelessWidget {
               controlWidth: controlWidth,
             ),
           const ControlPanelDivider(),
-
           LabeledControl(
             label: 'controls.visual_debugging',
             control: CheckboxList(

--- a/controller/lib/widgets/control_panel/control_panel.dart
+++ b/controller/lib/widgets/control_panel/control_panel.dart
@@ -21,9 +21,9 @@ class ControlPanel extends StatelessWidget {
 
   const ControlPanel({
     required this.manager,
-    Key? key,
+    super.key,
     this.width = 353,
-  }) : super(key: key);
+  });
   static const controlWidth = 250.0;
 
   @override
@@ -159,7 +159,7 @@ class ControlPanel extends StatelessWidget {
 }
 
 class ControlPanelDivider extends StatelessWidget {
-  const ControlPanelDivider({Key? key}) : super(key: key);
+  const ControlPanelDivider({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/controller/lib/widgets/control_panel/control_panel.dart
+++ b/controller/lib/widgets/control_panel/control_panel.dart
@@ -1,5 +1,7 @@
 // import 'dart:io';
 
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:monarch_definitions/monarch_definitions.dart';
 import 'package:stockholm/stockholm.dart';
@@ -96,37 +98,33 @@ class ControlPanel extends StatelessWidget {
           ),
           const ControlPanelDivider(),
 
-          /// @GOTCHA: Removed because it was broken on Flutter 3.22. See issue #143.
-          /// On windows: the status and dock dropdowns crashed the preview window
-          /// On macOS: the status dropdown froze afer selection
-          ///
-          // LabeledControl(
-          //   label: 'controls.scale',
-          //   control: DropDown<StoryScaleDefinition>(
-          //     currentValue: state.currentScale,
-          //     values: state.scaleList.toList(),
-          //     skipTraversal: true,
-          //     onChange: actions.onScaleChanged,
-          //     toStringFunction: (e) => e.name,
-          //   ),
-          //   controlWidth: controlWidth,
-          // ),
-          // const SizedBox(
-          //   height: 8,
-          // ),
-          // if (!Platform.isLinux) // hidden on linux until it supports docking
-          //   LabeledControl(
-          //     label: 'controls.dock',
-          //     control: DropDown<DockDefinition>(
-          //       currentValue: state.currentDock,
-          //       values: state.dockList.toList(),
-          //       skipTraversal: true,
-          //       onChange: actions.onDockSettingsChange,
-          //       toStringFunction: (e) => translations.text(e.name),
-          //     ),
-          //     controlWidth: controlWidth,
-          //   ),
-          // const ControlPanelDivider(),
+          LabeledControl(
+            label: 'controls.scale',
+            control: DropDown<StoryScaleDefinition>(
+              currentValue: state.currentScale,
+              values: state.scaleList.toList(),
+              skipTraversal: true,
+              onChange: actions.onScaleChanged,
+              toStringFunction: (e) => e.name,
+            ),
+            controlWidth: controlWidth,
+          ),
+          const SizedBox(
+            height: 8,
+          ),
+          if (!Platform.isLinux) // hidden on linux until it supports docking
+            LabeledControl(
+              label: 'controls.dock',
+              control: DropDown<DockDefinition>(
+                currentValue: state.currentDock,
+                values: state.dockList.toList(),
+                skipTraversal: true,
+                onChange: actions.onDockSettingsChange,
+                toStringFunction: (e) => translations.text(e.name),
+              ),
+              controlWidth: controlWidth,
+            ),
+          const ControlPanelDivider(),
 
           LabeledControl(
             label: 'controls.visual_debugging',

--- a/controller/lib/widgets/story_list/search_field.dart
+++ b/controller/lib/widgets/story_list/search_field.dart
@@ -3,14 +3,14 @@ import 'package:flutter/material.dart';
 
 class SearchField extends StatelessWidget {
   const SearchField({
-    Key? key,
+    super.key,
     required this.controller,
     this.onChanged,
     this.canReset = false,
     this.hint,
     this.onReset,
     this.focusNode,
-  }) : super(key: key);
+  });
 
   final TextEditingController controller;
   final Function(String)? onChanged;

--- a/controller/lib/widgets/story_list/story_list.dart
+++ b/controller/lib/widgets/story_list/story_list.dart
@@ -10,12 +10,12 @@ import '../components/no_stories_found_text.dart';
 
 class StoryList extends StatefulWidget {
   const StoryList({
-    Key? key,
+    super.key,
     required this.stories,
     required this.projectName,
     required this.manager,
     this.activeStoryId,
-  }) : super(key: key);
+  });
 
   final List<StoryGroup> stories;
   final String projectName;

--- a/controller/lib/widgets/story_list/story_tree.dart
+++ b/controller/lib/widgets/story_list/story_tree.dart
@@ -14,12 +14,12 @@ class StoryTree extends StatefulWidget {
   final Function(StoryId)? onStorySelected;
 
   const StoryTree({
-    Key? key,
+    super.key,
     required this.filteredStories,
     this.focusNode,
     this.onStorySelected,
     this.query = '',
-  }) : super(key: key);
+  });
 
   @override
   State<StoryTree> createState() => _StoryTreeState();

--- a/controller/lib/widgets/story_list/text_with_highlight.dart
+++ b/controller/lib/widgets/story_list/text_with_highlight.dart
@@ -7,8 +7,7 @@ class TextWithHighlight extends StatelessWidget {
   final String text;
 
   const TextWithHighlight(
-      {Key? key, required this.text, this.highlightedText = ''})
-      : super(key: key);
+      {super.key, required this.text, this.highlightedText = ''});
 
   @override
   Widget build(BuildContext context) {

--- a/controller/lib/widgets/tree_view/builder.dart
+++ b/controller/lib/widgets/tree_view/builder.dart
@@ -1,4 +1,4 @@
-///Code credits to https://pub.dev/packages/flutter_simple_treeview
+//Code credits to https://pub.dev/packages/flutter_simple_treeview
 
 import 'package:flutter/material.dart';
 

--- a/controller/lib/widgets/tree_view/copy_tree_nodes.dart
+++ b/controller/lib/widgets/tree_view/copy_tree_nodes.dart
@@ -1,4 +1,4 @@
-///Code credits to https://pub.dev/packages/flutter_simple_treeview
+//Code credits to https://pub.dev/packages/flutter_simple_treeview
 
 import 'primitives/key_provider.dart';
 import 'primitives/tree_node.dart';

--- a/controller/lib/widgets/tree_view/flutter_simple_treeview.dart
+++ b/controller/lib/widgets/tree_view/flutter_simple_treeview.dart
@@ -1,4 +1,4 @@
-///Code credits to https://pub.dev/packages/flutter_simple_treeview
+//Code credits to https://pub.dev/packages/flutter_simple_treeview
 
 export 'primitives/tree_controller.dart';
 export 'primitives/tree_node.dart';

--- a/controller/lib/widgets/tree_view/node_widget.dart
+++ b/controller/lib/widgets/tree_view/node_widget.dart
@@ -1,4 +1,4 @@
-///Code credits to https://pub.dev/packages/flutter_simple_treeview
+//Code credits to https://pub.dev/packages/flutter_simple_treeview
 
 import 'package:flutter/material.dart';
 
@@ -16,14 +16,14 @@ class NodeWidget extends StatefulWidget {
   final VoidCallback? onFocus;
 
   const NodeWidget({
-    Key? key,
+    super.key,
     required this.treeNode,
     this.indent,
     required this.state,
     this.iconSize,
     this.updateRoot,
     this.onFocus,
-  }) : super(key: key);
+  });
 
   @override
   NodeWidgetState createState() => NodeWidgetState();

--- a/controller/lib/widgets/tree_view/primitives/key_provider.dart
+++ b/controller/lib/widgets/tree_view/primitives/key_provider.dart
@@ -1,13 +1,13 @@
-///Code credits to https://pub.dev/packages/flutter_simple_treeview
+//Code credits to https://pub.dev/packages/flutter_simple_treeview
 
 import 'package:flutter/material.dart';
 
 class NodeKey extends ValueKey {
-  const NodeKey(dynamic value) : super(value);
+  const NodeKey(super.value);
 }
 
 class LeafKey extends ValueKey {
-  const LeafKey(dynamic value) : super(value);
+  const LeafKey(super.value);
 }
 
 /// Provides unique keys and verifies duplicates.

--- a/controller/lib/widgets/tree_view/primitives/tree_controller.dart
+++ b/controller/lib/widgets/tree_view/primitives/tree_controller.dart
@@ -1,4 +1,4 @@
-///Code credits to https://pub.dev/packages/flutter_simple_treeview
+//Code credits to https://pub.dev/packages/flutter_simple_treeview
 
 import 'package:flutter/foundation.dart';
 import 'package:monarch_controller/widgets/tree_view/primitives/key_provider.dart';

--- a/controller/lib/widgets/tree_view/primitives/tree_node.dart
+++ b/controller/lib/widgets/tree_view/primitives/tree_node.dart
@@ -1,4 +1,4 @@
-///Code credits to https://pub.dev/packages/flutter_simple_treeview
+//Code credits to https://pub.dev/packages/flutter_simple_treeview
 
 import 'package:flutter/material.dart';
 

--- a/controller/lib/widgets/tree_view/tree_view.dart
+++ b/controller/lib/widgets/tree_view/tree_view.dart
@@ -1,4 +1,4 @@
-///Code credits to https://pub.dev/packages/flutter_simple_treeview
+//Code credits to https://pub.dev/packages/flutter_simple_treeview
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -28,15 +28,14 @@ class TreeView extends StatefulWidget {
   final Function(Key)? onNodeChanged;
 
   TreeView({
-    Key? key,
+    super.key,
     required List<TreeNode> nodes,
     this.indent = 40,
     this.iconSize,
     this.focusNode,
     required this.treeController,
     this.onNodeChanged,
-  })  : nodes = copyTreeNodes(nodes, treeController.keyProvider),
-        super(key: key);
+  })  : nodes = copyTreeNodes(nodes, treeController.keyProvider);
 
   @override
   TreeViewState createState() => TreeViewState();

--- a/controller/lib/widgets/tree_view/tree_view.dart
+++ b/controller/lib/widgets/tree_view/tree_view.dart
@@ -35,7 +35,7 @@ class TreeView extends StatefulWidget {
     this.focusNode,
     required this.treeController,
     this.onNodeChanged,
-  })  : nodes = copyTreeNodes(nodes, treeController.keyProvider);
+  }) : nodes = copyTreeNodes(nodes, treeController.keyProvider);
 
   @override
   TreeViewState createState() => TreeViewState();

--- a/controller/pubspec.yaml
+++ b/controller/pubspec.yaml
@@ -1,9 +1,7 @@
 name: monarch_controller
 description: Monarch Controller UI
-
 publish_to: 'none'
-
-version: 1.5.0
+version: 1.5.1
 
 environment:
   sdk: ^3.2.0
@@ -18,7 +16,7 @@ dependencies:
     sdk: flutter
   intl: any
   monarch_annotations: ^1.1.0
-  monarch_definitions: ^1.6.0
+  monarch_definitions: ^1.7.0
   monarch_io_utils: ^1.4.0
   monarch_utils: ^1.2.0
   grpc: ^4.0.1
@@ -42,4 +40,3 @@ flutter:
   assets:
     - locale/i18n_en.json
     - locale/i18n_es.json
-

--- a/controller/pubspec.yaml
+++ b/controller/pubspec.yaml
@@ -3,38 +3,38 @@ description: Monarch Controller UI
 
 publish_to: 'none'
 
-version: 1.4.2
+version: 1.5.0
 
 environment:
-  sdk: '>=2.16.1 <3.0.0'
+  sdk: ^3.2.0
 
 dependencies:
   flutter:
     sdk: flutter
 
   cupertino_icons: ^1.0.2
-  rxdart: ^0.27.3
+  rxdart: ^0.28.0
   flutter_localizations:
     sdk: flutter
   intl: any
-  monarch_annotations: 1.0.4
-  monarch_definitions: 1.5.1
-  monarch_io_utils: 1.3.0
-  monarch_utils: 1.1.0
-  grpc: ^3.2.4
-  monarch_grpc: 2.3.1
+  monarch_annotations: ^1.1.0
+  monarch_definitions: ^1.6.0
+  monarch_io_utils: ^1.4.0
+  monarch_utils: ^1.2.0
+  grpc: ^4.0.1
+  monarch_grpc: ^2.4.0
   stockholm:
     git:
       url: https://github.com/Dropsource/monarch_stockholm/
       ref: monarch_stockholm-1.0.0
-  syncfusion_flutter_core: ^25.0.0
-  syncfusion_flutter_sliders: ^25.0.0
+  syncfusion_flutter_core: ^28.2.9
+  syncfusion_flutter_sliders: ^28.2.9
 
 dev_dependencies:
   build_runner: ^2.1.11
   flutter_test:
     sdk: flutter
-  flutter_lints: ^2.0.1
+  flutter_lints: ^5.0.0
   monarch: ^3.0.0
 
 flutter:

--- a/packages/monarch/CHANGELOG.md
+++ b/packages/monarch/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 3.9.2
+- Upgrades monarch_definitions to 1.7.0
+
 ### 3.9.1
 - Upgrades monarch_* dependencies
 

--- a/packages/monarch/CHANGELOG.md
+++ b/packages/monarch/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 3.9.1
+- Upgrades monarch_* dependencies
+
 ### 3.9.0
 2025-03-06
 - Upgrades dependencies: source_gen, dart_style, analyzer, lints

--- a/packages/monarch/pubspec.yaml
+++ b/packages/monarch/pubspec.yaml
@@ -1,6 +1,6 @@
 name: monarch
 description: Code generator for Monarch. Monarch is a tool for building Flutter widgets in isolation. It makes it easy to build, test and debug complex UIs.
-version: 3.9.0
+version: 3.9.1
 homepage: https://monarchapp.io
 repository: https://github.com/Dropsource/monarch
 issue_tracker: https://github.com/Dropsource/monarch/issues
@@ -33,9 +33,9 @@ dependencies:
   build: ^2.0.0
   source_gen: ^2.0.0
   dart_style: ^3.0.1
-  monarch_definitions: ^1.5.0
-  monarch_annotations: ^1.0.0
-  monarch_utils: ^1.0.0
+  monarch_definitions: ^1.6.0
+  monarch_annotations: ^1.1.0
+  monarch_utils: ^1.2.0
   glob: ^2.0.1
   analyzer: ^7.3.0
   path: ^1.8.0

--- a/packages/monarch/pubspec.yaml
+++ b/packages/monarch/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
   build: ^2.0.0
   source_gen: ^2.0.0
   dart_style: ^3.0.1
-  monarch_definitions: ^1.6.0
+  monarch_definitions: ^1.7.0
   monarch_annotations: ^1.1.0
   monarch_utils: ^1.2.0
   glob: ^2.0.1

--- a/packages/monarch_definitions/CHANGELOG.md
+++ b/packages/monarch_definitions/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.7.0
+2025-03011
+- Adds enum values to `MonarchTargetPlatform`: macos, windows, linux
+
 ### 1.6.0
 2025-03-10
 - Update dependencies and sdk.

--- a/packages/monarch_definitions/lib/src/target_platform.dart
+++ b/packages/monarch_definitions/lib/src/target_platform.dart
@@ -1,7 +1,10 @@
-enum MonarchTargetPlatform { iOS, android }
+enum MonarchTargetPlatform { iOS, android, macos, windows, linux }
 
 const String _ios = 'ios';
 const String _android = 'android';
+const String _macos = 'macos';
+const String _windows = 'windows';
+const String _linux = 'linux';
 
 String targetPlatformToString(MonarchTargetPlatform platform) {
   switch (platform) {
@@ -9,6 +12,12 @@ String targetPlatformToString(MonarchTargetPlatform platform) {
       return _ios;
     case MonarchTargetPlatform.android:
       return _android;
+    case MonarchTargetPlatform.macos:
+      return _macos;
+    case MonarchTargetPlatform.windows:
+      return _windows;
+    case MonarchTargetPlatform.linux:
+      return _linux;
   }
 }
 
@@ -18,6 +27,12 @@ MonarchTargetPlatform targetPlatformFromString(String platform) {
       return MonarchTargetPlatform.iOS;
     case _android:
       return MonarchTargetPlatform.android;
+    case _macos:
+      return MonarchTargetPlatform.macos;
+    case _windows:
+      return MonarchTargetPlatform.windows;
+    case _linux:
+      return MonarchTargetPlatform.linux;
     default:
       throw 'Unexpected target platform string $platform';
   }

--- a/packages/monarch_definitions/pubspec.yaml
+++ b/packages/monarch_definitions/pubspec.yaml
@@ -1,6 +1,6 @@
 name: monarch_definitions
 description: Types and channel definitions for Monarch. Monarch is a tool for building Flutter widgets in isolation. It makes it easy to build, test and debug complex UIs.
-version: 1.6.0
+version: 1.7.0
 homepage: https://monarchapp.io
 repository: https://github.com/Dropsource/monarch
 issue_tracker: https://github.com/Dropsource/monarch/issues

--- a/packages/monarch_grpc/CHANGELOG.md
+++ b/packages/monarch_grpc/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 2.4.1 - 2025-03-10
+- Upgrades monarch_definitions dep
+
 ### 2.4.0 - 2025-03-06
 - Upgrades major versions of dependencies: grpc, protobuf, lints
 - Sets sdk constraint to ^3.2.0

--- a/packages/monarch_grpc/pubspec.yaml
+++ b/packages/monarch_grpc/pubspec.yaml
@@ -1,6 +1,6 @@
 name: monarch_grpc
 description: gRPC interfaces for Monarch. Monarch is a tool for building Flutter widgets in isolation. It makes it easy to build, test and debug complex UIs.
-version: 2.4.0
+version: 2.4.1
 homepage: https://monarchapp.io
 repository: https://github.com/Dropsource/monarch
 issue_tracker: https://github.com/Dropsource/monarch/issues
@@ -12,7 +12,7 @@ environment:
 dependencies:
   grpc: ^4.0.1
   protobuf: ^3.1.0
-  monarch_definitions: ^1.4.0
+  monarch_definitions: ^1.6.0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/packages/monarch_grpc/pubspec.yaml
+++ b/packages/monarch_grpc/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   grpc: ^4.0.1
   protobuf: ^3.1.0
-  monarch_definitions: ^1.6.0
+  monarch_definitions: ^1.7.0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/packages/monarch_http/CHANGELOG.md
+++ b/packages/monarch_http/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.3.1 - 2025-03-10
+- Upgrades monarch_utils dep
+
 ## 1.3.0 - 2025-03-06
 - Upgrades major versions of dependencies: http, lints
 - Upgrade sdk

--- a/packages/monarch_http/pubspec.yaml
+++ b/packages/monarch_http/pubspec.yaml
@@ -1,6 +1,6 @@
 name: monarch_http
 description: Http utilities for Monarch. Monarch is a tool for building Flutter widgets in isolation. It makes it easy to build, test and debug complex UIs.
-version: 1.3.0
+version: 1.3.1
 homepage: https://monarchapp.io
 repository: https://github.com/Dropsource/monarch
 issue_tracker: https://github.com/Dropsource/monarch/issues
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   http: ^1.3.0
-  monarch_utils: ^1.0.4
+  monarch_utils: ^1.2.0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.2.0 - 2025-03-12
+- monarch.yaml: passes project directory path to preview_api.
+
 ## 2.1.1 - 2022-06-02
 - Updated `defaultDeviceDefinition` to iPhone 14 data
 

--- a/platform/macos/monarch_macos.xcodeproj/project.pbxproj
+++ b/platform/macos/monarch_macos.xcodeproj/project.pbxproj
@@ -354,7 +354,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.1.1;
+				MARKETING_VERSION = 2.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "dropsource.monarch-macos";
 				PRODUCT_NAME = Monarch;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";
@@ -386,7 +386,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.1.1;
+				MARKETING_VERSION = 2.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "dropsource.monarch-macos";
 				PRODUCT_NAME = Monarch;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/platform/macos/monarch_macos/WindowManager.swift
+++ b/platform/macos/monarch_macos/WindowManager.swift
@@ -22,6 +22,7 @@ class WindowManager {
     var controllerBundlePath: String?
     var cliGrpcServerPort: String?
     var projectName: String?
+    var projectDirectoryPath: String?
     
     var previewApi: FlutterEngine?
     var controllerWindow: NSWindow?
@@ -57,8 +58,8 @@ class WindowManager {
         
         logger.fine("arguments \(arguments)");
         
-        if (arguments.count < 7) {
-            fatalError("Expected 6 arguments in this order: executable-path preview-api-bundle preview-window-bundle controller-bundle log-level cli-grpc-server-port project-name")
+        if (arguments.count < 8) {
+            fatalError("Expected 7 arguments in this order: executable-path preview-api-bundle preview-window-bundle controller-bundle log-level cli-grpc-server-port project-name project-directory-path")
         }
         
         previewApiBundlePath = arguments[1]
@@ -67,6 +68,7 @@ class WindowManager {
         defaultLogLevel = logLevelFromString(levelString: arguments[4])
         cliGrpcServerPort = arguments[5]
         projectName = arguments[6]
+        projectDirectoryPath = arguments[7]
         
         self._loadWindows()
     }
@@ -77,7 +79,7 @@ class WindowManager {
         let controllerProject = _initDartProject(controllerBundlePath!)
         
         previewApiProject.dartEntrypointArguments = [
-            logLevelToString(level: defaultLogLevel), cliGrpcServerPort!]
+            logLevelToString(level: defaultLogLevel), cliGrpcServerPort!, projectDirectoryPath!]
         previewWindowProject.dartEntrypointArguments = [
             logLevelToString(level: defaultLogLevel)]
         controllerProject.dartEntrypointArguments = [

--- a/platform/windows/src/main.cpp
+++ b/platform/windows/src/main.cpp
@@ -94,6 +94,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
     std::string previewWindowBundlePath = trim_copy(arguments[2]);
     std::string defaultLogLevelString = trim_copy(arguments[3]);
     std::string cliGrpcServerPort = trim_copy(arguments[4]);
+    std::string projectDirectoryPath = trim_copy(arguments[5]);
 
     defaultLogLevel = logLevelFromString(defaultLogLevelString);
 
@@ -103,7 +104,8 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
       previewApiBundlePath,
       previewWindowBundlePath,
       defaultLogLevelString,
-      cliGrpcServerPort);
+      cliGrpcServerPort,
+      projectDirectoryPath);
     manager.launchPreviewWindow();
     manager.runPreviewApi();
     manager.setUpChannels();

--- a/platform/windows/src/window_manager.cpp
+++ b/platform/windows/src/window_manager.cpp
@@ -85,12 +85,14 @@ PreviewWindowManager::PreviewWindowManager(
 	std::string previewApiBundlePath,
 	std::string previewWindowBundlePath,
 	std::string defaultLogLevelString,
-	std::string cliGrpcServerPort)
+	std::string cliGrpcServerPort,
+	std::string projectDirectoryPath)
 {
 	_previewApiBundlePath = previewApiBundlePath;
 	_previewWindowBundlePath = previewWindowBundlePath;
 	_defaultLogLevelString = defaultLogLevelString;
 	_cliGrpcServerPort = cliGrpcServerPort;
+	_projectDirectoryPath = projectDirectoryPath; 
 
 	_previewApi = nullptr;
 	_previewWindow = nullptr;
@@ -124,7 +126,7 @@ void PreviewWindowManager::launchPreviewWindow()
 void PreviewWindowManager::runPreviewApi()
 {
 	flutter::DartProject previewApiProject(to_wstring(_previewApiBundlePath));
-	std::vector<std::string> apiArguments = { _defaultLogLevelString, _cliGrpcServerPort };
+	std::vector<std::string> apiArguments = { _defaultLogLevelString, _cliGrpcServerPort, _projectDirectoryPath };
 	previewApiProject.set_dart_entrypoint_arguments(apiArguments);
 
 	_previewApi = std::make_unique<PreviewApiRunner>(previewApiProject);

--- a/platform/windows/src/window_manager.h
+++ b/platform/windows/src/window_manager.h
@@ -43,7 +43,8 @@ public:
 		std::string previewServerBundlePath,
 		std::string previewWindowBundlePath,
 		std::string defaultLogLevelString,
-		std::string cliGrpcServerPort);
+		std::string cliGrpcServerPort,
+		std::string projectDirectoryPath);
 	~PreviewWindowManager();
 
 	HWND controllerWindowHandle;
@@ -67,6 +68,7 @@ private:
 	std::string _previewApiBundlePath;
 	std::string _defaultLogLevelString;
 	std::string _cliGrpcServerPort;
+	std::string _projectDirectoryPath;
 
 	std::unique_ptr<PreviewWindow> _previewWindow;
 	std::unique_ptr<PreviewApiRunner> _previewApi;

--- a/preview_api/CHANGELOG.md
+++ b/preview_api/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.5.0 - 2025-03-10
+- Upgrades dependencies, dart sdk, and flutter sdk.
+
 ## 2.4.1 - 2023-11-02
 - Use point versions for monarch_* packages.
 - Using monarch_definitions `1.5.1` which rolls back Material 3 standard themes.

--- a/preview_api/CHANGELOG.md
+++ b/preview_api/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 2.5.0 - 2025-03-10
+## 2.5.1 - 2025-03-10
 - Upgrades dependencies, dart sdk, and flutter sdk.
+- Reads monarch.yaml
 
 ## 2.4.1 - 2023-11-02
 - Use point versions for monarch_* packages.

--- a/preview_api/lib/src/monarch_yaml_reader.dart
+++ b/preview_api/lib/src/monarch_yaml_reader.dart
@@ -1,0 +1,53 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:yaml/yaml.dart';
+import 'package:monarch_definitions/monarch_definitions.dart';
+import 'package:monarch_utils/log.dart';
+
+class MonarchYamlReader with Log {
+  final String projectDirectoryPath;
+  MonarchYamlReader(this.projectDirectoryPath);
+
+  bool _hasYamlFile = false;
+  bool get hasYamlFile => _hasYamlFile;
+
+  String get monarchYamlPath => p.join(projectDirectoryPath, 'monarch.yaml');
+
+  List<DeviceDefinition> devices = [];
+  bool get hasDevices => hasYamlFile && devices.isNotEmpty;
+
+  Future<void> read() async {
+    final monarchYamlFile = File(monarchYamlPath);
+    if (!await monarchYamlFile.exists()) {
+      _hasYamlFile = false;
+      return;
+    }
+    _hasYamlFile = true;
+
+    try {
+      final contents = await monarchYamlFile.readAsString();
+      devices.addAll(getDevicesFromMonarchYaml(contents));
+    } catch (err, stack) {
+      log.warning('Error processing monarch.yaml file', err, stack);
+    }
+  }
+
+  static Iterable<DeviceDefinition> getDevicesFromMonarchYaml(
+      String yamlContents) {
+    final yaml = loadYaml(yamlContents);
+    if (yaml['devices'] == null) {
+      return [];
+    }
+    final devicesYaml = yaml['devices'] as List;
+
+    return devicesYaml.map((device) => DeviceDefinition(
+        id: device['id'],
+        name: device['name'],
+        logicalResolution: LogicalResolution(
+            width: (device['width'] as num).toDouble(),
+            height: (device['height'] as num).toDouble()),
+        devicePixelRatio: (device['device_pixel_ratio'] as num).toDouble(),
+        targetPlatform: targetPlatformFromString(device['platform'])));
+  }
+}

--- a/preview_api/lib/src/monarch_yaml_reader.dart
+++ b/preview_api/lib/src/monarch_yaml_reader.dart
@@ -19,15 +19,19 @@ class MonarchYamlReader with Log {
 
   Future<void> read() async {
     final monarchYamlFile = File(monarchYamlPath);
+    log.fine('Looking for monarch.yaml at $monarchYamlPath');
     if (!await monarchYamlFile.exists()) {
+      log.fine('monarch.yaml not found');
       _hasYamlFile = false;
       return;
     }
+    log.fine('monarch.yaml found');
     _hasYamlFile = true;
 
     try {
       final contents = await monarchYamlFile.readAsString();
       devices.addAll(getDevicesFromMonarchYaml(contents));
+      log.fine('Found ${devices.length} devices in monarch.yaml');
     } catch (err, stack) {
       log.warning('Error processing monarch.yaml file', err, stack);
     }

--- a/preview_api/lib/src/project_data.dart
+++ b/preview_api/lib/src/project_data.dart
@@ -5,12 +5,11 @@ import 'package:monarch_grpc/monarch_grpc.dart';
 
 class ProjectData extends ProjectDataDefinition {
   ProjectData({
-    required String packageName,
+    required super.packageName,
     required Map<String, MetaStoriesDefinition> storiesMap,
     required List<MetaThemeDefinition> themes,
     required List<MetaLocalizationDefinition> localizations,
   }) : super(
-            packageName: packageName,
             metaStoriesDefinitionMap: storiesMap,
             metaThemeDefinitions: themes,
             metaLocalizationDefinitions: localizations);

--- a/preview_api/pubspec.yaml
+++ b/preview_api/pubspec.yaml
@@ -1,7 +1,7 @@
 name: preview_api
 description: The Monarch Preview API
 publish_to: 'none'
-version: 2.5.0
+version: 2.5.1
 
 environment:
   sdk: ^3.2.0
@@ -12,9 +12,11 @@ dependencies:
     sdk: flutter
   monarch_utils: ^1.2.0
   monarch_io_utils: ^1.4.0
-  monarch_definitions: ^1.6.0
+  monarch_definitions: ^1.7.0
   monarch_grpc: ^2.4.0
   grpc: ^4.0.1
+  path: ^1.8.2
+  yaml: ^3.1.1
 
 dev_dependencies:
   flutter_test:

--- a/preview_api/pubspec.yaml
+++ b/preview_api/pubspec.yaml
@@ -1,24 +1,24 @@
 name: preview_api
 description: The Monarch Preview API
 publish_to: 'none'
-version: 2.4.1
+version: 2.5.0
 
 environment:
-  sdk: '>=2.16.1 <3.0.0'
-  flutter: ">=1.17.0"
+  sdk: ^3.2.0
+  flutter: '>=3.22.0-0.1.pre'
 
 dependencies:
   flutter:
     sdk: flutter
-  monarch_utils: 1.1.0
-  monarch_io_utils: 1.3.0
-  monarch_definitions: 1.5.1
-  monarch_grpc: 2.3.1
-  grpc: ^3.2.4
+  monarch_utils: ^1.2.0
+  monarch_io_utils: ^1.4.0
+  monarch_definitions: ^1.6.0
+  monarch_grpc: ^2.4.0
+  grpc: ^4.0.1
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^2.0.1
+  flutter_lints: ^5.0.0
 
 flutter:

--- a/preview_api/test/monarch_yaml_reader_test.dart
+++ b/preview_api/test/monarch_yaml_reader_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monarch_definitions/monarch_definitions.dart';
+import 'package:preview_api/src/monarch_yaml_reader.dart';
+
+void main() {
+  group('getDevicesFromMonarchYaml', () {
+    test('should parse devices from valid yaml', () {
+      final yamlContents = '''
+      devices:
+        - id: device1
+          name: Device One
+          width: 1080
+          height: 1920
+          device_pixel_ratio: 2.0
+          platform: android
+        - id: device2
+          name: Device Two
+          width: 750
+          height: 1334
+          device_pixel_ratio: 2.0
+          platform: ios
+      ''';
+
+      final devices =
+          MonarchYamlReader.getDevicesFromMonarchYaml(yamlContents).toList();
+
+      expect(devices.length, 2);
+      expect(devices[0].id, 'device1');
+      expect(devices[0].name, 'Device One');
+      expect(devices[0].logicalResolution.width, 1080);
+      expect(devices[0].logicalResolution.height, 1920);
+      expect(devices[0].devicePixelRatio, 2.0);
+      expect(devices[0].targetPlatform, MonarchTargetPlatform.android);
+
+      expect(devices[1].id, 'device2');
+      expect(devices[1].name, 'Device Two');
+      expect(devices[1].logicalResolution.width, 750);
+      expect(devices[1].logicalResolution.height, 1334);
+      expect(devices[1].devicePixelRatio, 2.0);
+      expect(devices[1].targetPlatform, MonarchTargetPlatform.iOS);
+    });
+
+    test('should return empty list for yaml without devices', () {
+      final yamlContents = '''
+      foo: bar
+      ''';
+
+      final devices =
+          MonarchYamlReader.getDevicesFromMonarchYaml(yamlContents).toList();
+
+      expect(devices.isEmpty, true);
+    });
+
+    test('should return empty list for empty yaml devices', () {
+      final yamlContents = '''
+      devices: 
+      ''';
+
+      final devices =
+          MonarchYamlReader.getDevicesFromMonarchYaml(yamlContents).toList();
+
+      expect(devices.isEmpty, true);
+    });
+  });
+}

--- a/test/test_create/pubspec.yaml
+++ b/test/test_create/pubspec.yaml
@@ -3,7 +3,7 @@ description: Monarch integration tests to test new projects.
 version: 
 
 environment:
-  sdk: '>=2.16.1 <3.0.0'
+  sdk: ^3.2.0
 
 dev_dependencies:
   test_process:

--- a/test/test_localizations/pubspec.yaml
+++ b/test/test_localizations/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.19.6 <3.0.0'
+  sdk: ^3.2.0
 
 dependencies:
   flutter:

--- a/test/test_stories/pubspec.yaml
+++ b/test/test_stories/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.19.6 <3.0.0'
+  sdk: ^3.2.0
 
 dependencies:
   flutter:

--- a/test/test_themes/pubspec.yaml
+++ b/test/test_themes/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.19.6 <3.0.0'
+  sdk: ^3.2.0
 
 dependencies:
   flutter:

--- a/test/utils/pubspec.yaml
+++ b/test/utils/pubspec.yaml
@@ -3,7 +3,7 @@ description: Utils for Monarch integration tests.
 version: 1.0.0
 
 environment:
-  sdk: '>=2.16.1 <3.0.0'
+  sdk: ^3.2.0
 
 dev_dependencies:
   test_process:
@@ -12,4 +12,4 @@ dev_dependencies:
   monarch_utils:
   monarch_io_utils:
   monarch_grpc:
-  grpc: ^3.1.0
+  grpc: ^4.0.1

--- a/tools/pubspec.yaml
+++ b/tools/pubspec.yaml
@@ -3,7 +3,7 @@ description:
 version: 
 
 environment:
-  sdk: '>=2.16.1 <3.0.0'
+  sdk: ^3.2.0
 
 dev_dependencies:
   path:

--- a/tools/test.dart
+++ b/tools/test.dart
@@ -120,6 +120,7 @@ Future<Map<String, List<TestResult>>> testAllModulesSingleFlutterSdk(
 
   results.add(await _test(flutter_sdk, monarch_exe_, 'cli'));
   results.add(await _test(flutter_sdk, monarch_exe_, 'controller'));
+  results.add(await _test(flutter_sdk, monarch_exe_, 'preview_api'));
   results.add(await _test(flutter_sdk, monarch_exe_, 'packages/monarch'));
   results.add(
       await _test(flutter_sdk, monarch_exe_, 'packages/monarch_io_utils'));


### PR DESCRIPTION
Introduces monarch.yaml file which can be placed at the root of the user's project directory. monarch.yaml lets users define the devices they want to use with Monarch.
    
Implementation details:
- cli: monarch.yaml: Passes project directory path to platform window managers, i.e. monarch app processes
- controller: Puts back dock dropdown
- monarch_definitions: adds new platforms macos, windows, linux
- macos: passes project directory path to preview_api.
- preview_api: reads devices from monarch.yaml
- preview_api: tests reading devices from monarch.yaml
- Upgrades monarch components and packages to use monarch_definitions 1.7.0

Other details:
- Upgrades dependencies, Dart SDK, Flutter SDK
- Fixes lints
- Uses latest monarch packages
- Adds enum values to MonarchTargetPlatform: macos, windows, linux

