### PR TITLE
cli: Bumps monarch package compatibility to 3.9.2

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.1 - 2025-04-01
+- Bumps monarch package compatibility to 3.9.2 due to new 
+  monarch definitions.
+
 ## 3.1.0 - 2025-03-10
 - Upgrades monarch_* package dependencies
 - Sets dart sdk constraint to ^3.2.0

--- a/cli/lib/src/config/monarch_package_compatibility.dart
+++ b/cli/lib/src/config/monarch_package_compatibility.dart
@@ -5,6 +5,7 @@ import 'package:pub_semver/pub_semver.dart' as pub;
 final monarchPackage_2_1 = pub.Version(2, 1, 0);
 final monarchPackage_2_2 = pub.Version(2, 2, 0);
 final monarchPackage_3_0 = pub.Version(3, 0, 0);
+final monarchPackage_3_9 = pub.Version(3, 9, 2);
 
 final buildRunnerPackage2 = pub.Version(2, 1, 11);
 
@@ -21,7 +22,7 @@ class MonarchPackageCompatibility {
   /// test/monarch_package_compatibility_test.dart
   /// and change it as needed to test for the new version boundaries
   pub.Version get monarchPackageMinimumCompatibleVersion =>
-      monarchPackage_3_0;
+      monarchPackage_3_9;
 
   /// Version of package:monarch that `monarch init` uses.
   ///
@@ -29,7 +30,7 @@ class MonarchPackageCompatibility {
   /// be different. The init version is what we want new projects to use, which
   /// is usually the latest version. The minimum compatible version is the oldest
   /// version of package:monarch that this version of the CLI is compatible with.
-  pub.Version get monarchPackageInitVersion => monarchPackage_3_0;
+  pub.Version get monarchPackageInitVersion => monarchPackage_3_9;
 
   /// Version of package:build_runner that `monarch init` uses.
   pub.Version get buildRunnerPackageInitVersion => buildRunnerPackage2;

--- a/cli/pubspec.yaml
+++ b/cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: monarch_cli
 description: Command-line interface for Monarch binaries.
-version: 3.1.0
+version: 3.1.1
 publish_to: none
 
 environment:

--- a/cli/test/monarch_package_compatibility_test.dart
+++ b/cli/test/monarch_package_compatibility_test.dart
@@ -18,22 +18,22 @@ void main() {
   group('MonarchPackageCompatibility', () {
     group('any supported flutter version', () {
       test('is compatible', () {
-        isCompatible(flutter: '3.3.6', monarch: '3.0.0');
-        isCompatible(flutter: '3.3.3', monarch: '3.0.1');
-        isCompatible(flutter: '3.3.2', monarch: '3.1.1');
+        isCompatible(flutter: '3.29.2', monarch: '3.9.2');
+        isCompatible(flutter: '3.29.2', monarch: '3.9.3');
+        isCompatible(flutter: '3.29.1', monarch: '3.10.0');
       });
 
       test('is incompatible', () {
-        isIncompatible(flutter: '3.3.6', monarch: '2.4.0-pre.5');
-        isIncompatible(flutter: '3.3.3', monarch: '2.4.0-pre.1');
-        isIncompatible(flutter: '3.3.2', monarch: '2.3.0-pre.2');
+        isIncompatible(flutter: '3.29.6', monarch: '3.9.1');
+        isIncompatible(flutter: '3.29.3', monarch: '3.9.0');
+        isIncompatible(flutter: '3.29.2', monarch: '3.8.1');
         isIncompatible(flutter: '3.0.5', monarch: '2.3.9');
         isIncompatible(flutter: '2.5.1', monarch: '1.0.2');
       });
 
       test('incompatibilityMessage', () {
-        expect(MonarchPackageCompatibility('3.0.5').incompatibilityMessage,
-            'Use monarch package version ^3.0.0 or greater.');
+        expect(MonarchPackageCompatibility('3.29.2').incompatibilityMessage,
+            'Use monarch package version ^3.9.2 or greater.');
       });
     });
   });


### PR DESCRIPTION
Bumps monarch package compatibility to 3.9.2 to make sure the monarch package in user's projects uses the new monarch definitions from monarch_definitions package.