### PR TITLE
monarch package: Adds build_runner dependency, fixes #161

### DIFF
--- a/packages/monarch/CHANGELOG.md
+++ b/packages/monarch/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 3.9.4
+- Sets build_runner dependency to `>=2.1.11 <=2.4.15`.
+
 ### 3.9.3
 - Upgrades vm_service dependency to `>=9.4.0 <16.0.0`.
 

--- a/packages/monarch/pubspec.yaml
+++ b/packages/monarch/pubspec.yaml
@@ -1,6 +1,6 @@
 name: monarch
 description: Code generator for Monarch. Monarch is a tool for building Flutter widgets in isolation. It makes it easy to build, test and debug complex UIs.
-version: 3.9.3
+version: 3.9.4
 homepage: https://monarchapp.io
 repository: https://github.com/Dropsource/monarch
 issue_tracker: https://github.com/Dropsource/monarch/issues
@@ -31,6 +31,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   build: ^2.0.0
+  build_runner: '>=2.1.11 <=2.4.15'
   source_gen: ^2.0.0
   dart_style: ^3.0.1
   monarch_definitions: ^1.7.0


### PR DESCRIPTION
When Monarch uses build_runner 2.5.x to build the preview-bundle it fails as detailed in the issue.

This fix sets bounds around
the build_runner dependency by adding them to the monarch package. This way, when `monarch init` adds the `build_runner` dependency, it will be constrained by the version range declared in the monarch package.